### PR TITLE
Styling refactor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { AppHeaderOptions } from './AppHeaderOptions';
 import { NewThreadCard } from './NewThreadCard';
 import { UserSet } from './UserSet';
 
+import { IPerson, IAnnotationResponse } from './app';
+
 /**
  * React States interface
  */
@@ -18,9 +20,9 @@ interface IAppStates {
   /**
    * Hold the users information
    *
-   * @type Person
+   * @type IPerson
    */
-  creator: object;
+  creator: IPerson;
   /**
    * Tracks if the current target has threads or not
    *
@@ -60,9 +62,9 @@ interface IAppStates {
   /**
    * State to hold last response
    *
-   * @type any
+   * @type IAnnotationResponse
    */
-  response: any;
+  response: IAnnotationResponse;
   /**
    * State to track when to query
    *
@@ -134,14 +136,14 @@ export default class App extends React.Component<IAppProps, IAppStates> {
   constructor(props: IAppProps) {
     super(props);
     this.state = {
-      creator: {},
+      creator: {} as IPerson,
       curTargetHasThreads: false,
       expandedCard: ' ',
       myThreads: [],
       newThreadActive: false,
       newThreadFile: ' ',
       replyActiveCard: ' ',
-      response: { data: { annotationsByTarget: { length: 0 } } },
+      response: {} as IAnnotationResponse,
       shouldQuery: true,
       showResolved: false,
       sortState: 'latest',
@@ -184,9 +186,10 @@ export default class App extends React.Component<IAppProps, IAppStates> {
    * Called each time the component updates
    */
   componentDidUpdate(): void {
+    console.log('Update');
     // Queries new data if there is a new target
-    if (this.state.response.data.annotationsByTarget !== undefined) {
-      if (this.state.response.data.annotationsByTarget.length !== 0) {
+    if (this.state.response.data !== undefined) {
+      if (this.state.response.data.annotationsByTarget !== undefined) {
         if (
           this.state.response.data.annotationsByTarget[0].target !==
             this.props.target &&

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,11 +98,11 @@ interface IAppProps {
    *
    * @type IMetadataCommentsService
    */
-  commentsService?: IMetadataCommentsService;
+  commentsService: IMetadataCommentsService;
   /**
    * People Service that communicates with graphql server
    */
-  peopleService?: IMetadataPeopleService;
+  peopleService: IMetadataPeopleService;
   /**
    * Path of open file, used as unique id to fetch comments and annotations
    *
@@ -136,7 +136,7 @@ export default class App extends React.Component<IAppProps, IAppStates> {
     this.state = {
       expandedCard: ' ',
       replyActiveCard: ' ',
-      newThreadFile: '',
+      newThreadFile: ' ',
       sortState: 'latest',
       showResolved: false,
       newThreadActive: false,
@@ -244,11 +244,11 @@ export default class App extends React.Component<IAppProps, IAppStates> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return this.state.userSet ? (
       <div className="jp-commenting-window">
         <AppHeader
-          header={this.props.targetName}
+          target={this.props.targetName}
           cardExpanded={this.state.expandedCard !== ' '}
           threadOpen={this.state.newThreadActive}
           setExpandedCard={this.setExpandedCard}
@@ -257,7 +257,7 @@ export default class App extends React.Component<IAppProps, IAppStates> {
               setSortState={this.setSortState}
               showResolvedState={this.showResolved}
               cardExpanded={this.state.expandedCard !== ' '}
-              header={this.props.targetName}
+              target={this.props.targetName}
               hasThreads={this.state.curTargetHasThreads}
               showResolved={this.state.showResolved}
               sortState={this.state.sortState}

--- a/src/AppBody.tsx
+++ b/src/AppBody.tsx
@@ -9,7 +9,7 @@ interface IAppBodyProps {
    *
    * @type React.ReactNode
    */
-  cards?: React.ReactNode[];
+  cards: React.ReactNode[];
   /**
    * Tracks if card is expanded
    *
@@ -38,7 +38,7 @@ export class AppBody extends React.Component<IAppBodyProps> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     const items = this.props.cards.map((card, i) => <div key={i}>{card}</div>);
 
     return (

--- a/src/AppBody.tsx
+++ b/src/AppBody.tsx
@@ -61,7 +61,7 @@ export class AppBody extends React.Component<IAppBodyProps> {
   styles = {
     'jp-commenting-body-area': {
       width: '100%',
-      maxHeight: '85vh',
+      maxHeight: '94%',
       overflowY: 'scroll' as 'scroll',
       overflowX: 'hidden' as 'hidden',
       boxSizing: 'border-box' as 'border-box',
@@ -70,7 +70,7 @@ export class AppBody extends React.Component<IAppBodyProps> {
     },
     'jp-commenting-body-area-expanded': {
       width: '100%',
-      maxHeight: '90vh',
+      maxHeight: '96%',
       overflowY: 'scroll' as 'scroll',
       overflowX: 'hidden' as 'hidden',
       boxSizing: 'border-box' as 'border-box',

--- a/src/AppBody.tsx
+++ b/src/AppBody.tsx
@@ -43,7 +43,11 @@ export class AppBody extends React.Component<IAppBodyProps> {
 
     return (
       <div
-        style={this.props.expanded ? this.bodyStyleExpanded : this.bodyStyle}
+        style={
+          this.props.expanded
+            ? this.styles['jp-commenting-body-area-expanded']
+            : this.styles['jp-commenting-body-area']
+        }
       >
         {!this.props.expanded && this.props.newThreadButton}
         {items}
@@ -54,22 +58,24 @@ export class AppBody extends React.Component<IAppBodyProps> {
   /**
    * CSS styles
    */
-  bodyStyle = {
-    width: '100%',
-    maxHeight: '81vh',
-    overflowY: 'scroll' as 'scroll',
-    overflowX: 'hidden' as 'hidden',
-    justifyContent: 'center',
-    padding: '4px'
-  };
-
-  bodyStyleExpanded = {
-    width: '100%',
-    maxHeight: '85vh',
-    overflowY: 'scroll' as 'scroll',
-    overflowX: 'hidden' as 'hidden',
-    justifyContent: 'center',
-    paddingRight: '5px',
-    paddingLeft: '5px'
+  styles = {
+    'jp-commenting-body-area': {
+      width: '100%',
+      maxHeight: '88vh',
+      overflowY: 'scroll' as 'scroll',
+      overflowX: 'hidden' as 'hidden',
+      boxSizing: 'border-box' as 'border-box',
+      justifyContent: 'center',
+      padding: '4px'
+    },
+    'jp-commenting-body-area-expanded': {
+      width: '100%',
+      maxHeight: '91vh',
+      overflowY: 'scroll' as 'scroll',
+      overflowX: 'hidden' as 'hidden',
+      boxSizing: 'border-box' as 'border-box',
+      justifyContent: 'center',
+      padding: '4px'
+    }
   };
 }

--- a/src/AppBody.tsx
+++ b/src/AppBody.tsx
@@ -61,7 +61,7 @@ export class AppBody extends React.Component<IAppBodyProps> {
   styles = {
     'jp-commenting-body-area': {
       width: '100%',
-      maxHeight: '88vh',
+      maxHeight: '85vh',
       overflowY: 'scroll' as 'scroll',
       overflowX: 'hidden' as 'hidden',
       boxSizing: 'border-box' as 'border-box',
@@ -70,7 +70,7 @@ export class AppBody extends React.Component<IAppBodyProps> {
     },
     'jp-commenting-body-area-expanded': {
       width: '100%',
-      maxHeight: '91vh',
+      maxHeight: '90vh',
       overflowY: 'scroll' as 'scroll',
       overflowX: 'hidden' as 'hidden',
       boxSizing: 'border-box' as 'border-box',

--- a/src/AppHeader.tsx
+++ b/src/AppHeader.tsx
@@ -257,15 +257,14 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
     'jp-commenting-header-area': {
       display: 'flex',
       flexDirection: 'column' as 'column',
-      borderBottom: '1px solid #e0e0e0',
+      borderBottom: '1px solid var(--jp-border-color1)',
       boxSizing: 'border-box' as 'border-box'
     },
     'jp-commenting-header-target-area': {
       display: 'flex',
       flexDirection: 'row' as 'row',
       paddingTop: '4px',
-      paddingBottom: '4px',
-      fontSize: 'var(--jp-ui-font-size1)'
+      paddingBottom: '4px'
     },
     'jp-commenting-back-arrow-area': {
       width: '20px',
@@ -292,7 +291,7 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
     },
     'jp-commenting-header-label': {
       fontSize: 'var(--jp-ui-font-size1)',
-      color: 'var(--jp-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       paddingLeft: '4px',
       textAlign: 'left' as 'left',
       whiteSpace: 'nowrap' as 'nowrap',

--- a/src/AppHeader.tsx
+++ b/src/AppHeader.tsx
@@ -9,19 +9,19 @@ interface IAppHeaderProps {
    *
    * @type string
    */
-  header?: string;
+  target: string;
   /**
    * Tracks if card is expanded
    *
    * @type boolean
    */
-  cardExpanded?: boolean;
+  cardExpanded: boolean;
   /**
    * Tracks if the new thread window is active
    *
    * @type boolean
    */
-  threadOpen?: boolean;
+  threadOpen: boolean;
   /**
    * Function to set the state of the current expanded card in "App.tsx"
    *
@@ -29,7 +29,7 @@ interface IAppHeaderProps {
    */
   setExpandedCard: (cardId: string) => void;
   /**
-   * Recieves the AppHeaderOption componenet for render purposes
+   * Receives the AppHeaderOption component for render purposes
    *
    * @type React.ReactNode
    */
@@ -56,14 +56,14 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div style={this.styles['jp-commenting-header-area']}>
         <div style={this.styles['jp-commenting-header-target-area']}>
           <div style={this.styles['jp-commenting-back-arrow-area']}>
             {this.getCornerButton()}
           </div>
-          {this.renderAppHeader(this.props.header)}
+          {this.renderAppHeader(this.props.target)}
         </div>
         {this.shouldRenderOptions()}
       </div>
@@ -89,7 +89,7 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
     } else {
       return (
         <div style={this.styles['jp-commenting-header-target-icon-container']}>
-          {this.getFileIcon(this.props.header)}
+          {this.getFileIcon(this.props.target)}
           <div style={this.styles['jp-commenting-header-label']}>{header}</div>
         </div>
       );
@@ -147,7 +147,7 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
    * @return Type: React.ReactNode
    */
   getCornerButton(): React.ReactNode {
-    if (this.props.cardExpanded && this.props.header !== undefined) {
+    if (this.props.cardExpanded && this.props.target !== undefined) {
       return this.getBackButton();
     } else {
       return;

--- a/src/AppHeader.tsx
+++ b/src/AppHeader.tsx
@@ -5,23 +5,17 @@ import * as React from 'react';
  */
 interface IAppHeaderProps {
   /**
-   * Receives a value for a header
-   *
-   * @type string
-   */
-  target: string;
-  /**
    * Tracks if card is expanded
    *
    * @type boolean
    */
   cardExpanded: boolean;
   /**
-   * Tracks if the new thread window is active
+   * Receives the AppHeaderOption component for render purposes
    *
-   * @type boolean
+   * @type React.ReactNode
    */
-  threadOpen: boolean;
+  headerOptions: React.ReactNode;
   /**
    * Function to set the state of the current expanded card in "App.tsx"
    *
@@ -29,11 +23,17 @@ interface IAppHeaderProps {
    */
   setExpandedCard: (cardId: string) => void;
   /**
-   * Receives the AppHeaderOption component for render purposes
+   * Receives a value for a header
    *
-   * @type React.ReactNode
+   * @type string
    */
-  headerOptions: React.ReactNode;
+  target: string;
+  /**
+   * Tracks if the new thread window is active
+   *
+   * @type boolean
+   */
+  threadOpen: boolean;
 }
 
 /**
@@ -48,7 +48,7 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
   constructor(props: IAppHeaderProps) {
     super(props);
 
-    this.renderAppHeader = this.renderAppHeader.bind(this);
+    this.getAppHeader = this.getAppHeader.bind(this);
     this.getBackButton = this.getBackButton.bind(this);
     this.setShrink = this.setShrink.bind(this);
   }
@@ -63,11 +63,24 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
           <div style={this.styles['jp-commenting-back-arrow-area']}>
             {this.getCornerButton()}
           </div>
-          {this.renderAppHeader(this.props.target)}
+          {this.getAppHeader(this.props.target)}
         </div>
         {this.shouldRenderOptions()}
       </div>
     );
+  }
+
+  /**
+   * Checks the state of New Thread
+   *
+   * @returns Type: React.ReactNode. If the New Thread is not open
+   */
+  shouldRenderOptions(): React.ReactNode {
+    if (!this.props.threadOpen && !this.props.cardExpanded) {
+      return <div>{this.props.headerOptions}</div>;
+    } else {
+      return <div />;
+    }
   }
 
   /**
@@ -77,7 +90,7 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
    * @param header Type: string
    * @return Type: React.ReactNode - App Header with correct string
    */
-  renderAppHeader(header: string): React.ReactNode {
+  getAppHeader(header: string): React.ReactNode {
     if (header === undefined) {
       return (
         <div style={this.styles['jp-commenting-header-target-icon-container']}>
@@ -125,19 +138,6 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
       );
     } catch {
       return <span />;
-    }
-  }
-
-  /**
-   * Checks the state of New Thread
-   *
-   * @returns Type: React.ReactNode. If the New Thread is not open
-   */
-  shouldRenderOptions(): React.ReactNode {
-    if (!this.props.threadOpen && !this.props.cardExpanded) {
-      return <div>{this.props.headerOptions}</div>;
-    } else {
-      return <div />;
     }
   }
 

--- a/src/AppHeader.tsx
+++ b/src/AppHeader.tsx
@@ -58,10 +58,12 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
    */
   render(): React.ReactNode {
     return (
-      <div style={this.styles['jp-commenting-header-area']}>
-        <div style={this.styles['jp-commenting-header-target-area']}>
+      <div style={this.styles['jp-commenting-app-header-area']}>
+        <div style={this.styles['jp-commenting-header-area']}>
           <div style={this.styles['jp-commenting-back-arrow-area']}>
-            {this.getCornerButton()}
+            {this.props.cardExpanded && this.props.target !== undefined
+              ? this.getBackButton()
+              : ''}
           </div>
           {this.getAppHeader(this.props.target)}
         </div>
@@ -93,17 +95,23 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
   getAppHeader(header: string): React.ReactNode {
     if (header === undefined) {
       return (
-        <div style={this.styles['jp-commenting-header-target-icon-container']}>
-          <div style={this.styles['jp-commenting-header-label']}>
-            Select a file to view comments
+        <div style={this.styles['jp-commenting-header-target-area']}>
+          <div style={this.styles['jp-commenting-header-label-area']}>
+            <label style={this.styles['jp-commenting-header-label']}>
+              Select a file to view comments
+            </label>
           </div>
         </div>
       );
     } else {
       return (
-        <div style={this.styles['jp-commenting-header-target-icon-container']}>
+        <div style={this.styles['jp-commenting-header-target-area']}>
           {this.getFileIcon(this.props.target)}
-          <div style={this.styles['jp-commenting-header-label']}>{header}</div>
+          <div style={this.styles['jp-commenting-header-label-area']}>
+            <label style={this.styles['jp-commenting-header-label']}>
+              {header}
+            </label>
+          </div>
         </div>
       );
     }
@@ -122,38 +130,28 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
         for (let value in this.fileTypes[key].extensions) {
           if (extensionName === this.fileTypes[key].extensions[value]) {
             return (
-              <span
-                className={this.fileTypes[key].iconClass}
-                style={this.styles['jp-commenting-header-icon']}
-              />
+              <div style={this.styles['jp-commenting-header-target-icon-area']}>
+                <span
+                  className={this.fileTypes[key].iconClass}
+                  style={this.styles['jp-commenting-header-target-icon']}
+                />
+              </div>
             );
           }
         }
       }
       return (
-        <span
-          className="jp-FileIcon"
-          style={this.styles['jp-commenting-header-icon']}
-        />
+        <div style={this.styles['jp-commenting-header-target-icon-area']}>
+          <span
+            className="jp-FileIcon"
+            style={this.styles['jp-commenting-header-target-icon']}
+          />
+        </div>
       );
     } catch {
       return <span />;
     }
   }
-
-  /**
-   * Returns a button from the current state of the comment box
-   *
-   * @return Type: React.ReactNode
-   */
-  getCornerButton(): React.ReactNode {
-    if (this.props.cardExpanded && this.props.target !== undefined) {
-      return this.getBackButton();
-    } else {
-      return;
-    }
-  }
-
   /**
    * Renders a back button inside the header
    *
@@ -164,7 +162,7 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
     return (
       <input
         type="image"
-        style={this.styles['jp-commenting-header-button-back']}
+        style={this.styles['jp-commenting-header-back-arrow']}
         src={'https://i.ibb.co/xg3hwy8/Vector.png'}
         onClick={this.setShrink}
       />
@@ -254,31 +252,45 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
    * App header styles
    */
   styles = {
-    'jp-commenting-header-area': {
+    'jp-commenting-app-header-area': {
       display: 'flex',
       flexDirection: 'column' as 'column',
       borderBottom: '1px solid var(--jp-border-color1)',
       boxSizing: 'border-box' as 'border-box'
     },
+    'jp-commenting-header-area': {
+      display: 'flex',
+      flexShrink: 1,
+      flexDirection: 'row' as 'row',
+      padding: '4px',
+      minWidth: '52px'
+    },
+    'jp-commenting-back-arrow-area': {
+      display: 'flex',
+      flexDirection: 'column' as 'column',
+      justifyContent: 'center',
+      width: '20px'
+    },
+    'jp-commenting-header-back-arrow': {
+      width: '12px',
+      height: '12px'
+    },
     'jp-commenting-header-target-area': {
       display: 'flex',
       flexDirection: 'row' as 'row',
-      paddingTop: '4px',
-      paddingBottom: '4px'
+      minWidth: '52px',
+      paddingLeft: '8px',
+      flexShrink: 1
     },
-    'jp-commenting-back-arrow-area': {
-      width: '20px',
-      marginLeft: '4px'
+    'jp-commenting-header-target-icon-area': {
+      display: 'flex'
     },
-    'jp-commenting-header-target-icon-container': {
-      display: 'flex',
-      flexDirection: 'row' as 'row',
-      minWidth: '75px',
-      paddingLeft: '8px'
+    'jp-commenting-header-target-icon': {
+      minWidth: '20px',
+      minHeight: '20px',
+      backgroundSize: '20px'
     },
-    'jp-commenting-header-label': {
-      fontSize: 'var(--jp-ui-font-size1)',
-      color: 'var(--jp-ui-font-color1)',
+    'jp-commenting-header-label-area': {
       paddingLeft: '4px',
       textAlign: 'left' as 'left',
       whiteSpace: 'nowrap' as 'nowrap',
@@ -286,16 +298,9 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
       textOverflow: 'ellipsis',
       flexShrink: 1
     },
-    'jp-commenting-header-icon': {
-      minWidth: '20px',
-      minHeight: '20px',
-      backgroundSize: '20px'
-    },
-    'jp-commenting-header-button-back': {
-      display: 'flex',
-      width: '12px',
-      height: '12px',
-      marginTop: '4px'
+    'jp-commenting-header-label': {
+      fontSize: 'var(--jp-ui-font-size1)',
+      color: 'var(--jp-ui-font-color1)'
     }
   };
 }

--- a/src/AppHeader.tsx
+++ b/src/AppHeader.tsx
@@ -80,10 +80,10 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
   renderAppHeader(header: string): React.ReactNode {
     if (header === undefined) {
       return (
-        <div>
-          <h5 style={this.styles['jp-commenting-header-text-empty']}>
+        <div style={this.styles['jp-commenting-header-target-icon-container']}>
+          <div style={this.styles['jp-commenting-header-label']}>
             Select a file to view comments
-          </h5>
+          </div>
         </div>
       );
     } else {
@@ -269,19 +269,6 @@ export class AppHeader extends React.Component<IAppHeaderProps> {
     'jp-commenting-back-arrow-area': {
       width: '20px',
       marginLeft: '4px'
-    },
-    'jp-commenting-header-text-empty': {
-      background: 'white',
-      fontSize: 'var(--jp-ui-font-size1)',
-      color: 'var( --jp-ui-font-color2)',
-      fontWeight: 400,
-      margin: '0px',
-      paddingLeft: '4px',
-      textAlign: 'left' as 'left',
-      whiteSpace: 'nowrap' as 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      flexShrink: 1
     },
     'jp-commenting-header-target-icon-container': {
       display: 'flex',

--- a/src/AppHeaderOptions.tsx
+++ b/src/AppHeaderOptions.tsx
@@ -102,8 +102,8 @@ export class AppHeaderOptions extends React.Component<
           {this.getSortItems()}
         </div>
         <div style={this.styles.optionBar}>
-          {this.renderCheckbox()}
-          {this.renderDropdown()}
+          {this.getCheckbox()}
+          {this.getDropdown()}
         </div>
       </div>
     );
@@ -114,7 +114,7 @@ export class AppHeaderOptions extends React.Component<
    *
    * @return React.ReactNode
    */
-  renderCheckbox(): React.ReactNode {
+  getCheckbox(): React.ReactNode {
     return (
       <div
         style={this.styles['jp-commenting-header-options-showResolved-area']}
@@ -172,7 +172,7 @@ export class AppHeaderOptions extends React.Component<
    *
    * @return React.ReactNode
    */
-  renderDropdown(): React.ReactNode {
+  getDropdown(): React.ReactNode {
     return (
       <div
         style={this.styles['jp-commenting-header-options-dropdown-area']}
@@ -213,32 +213,6 @@ export class AppHeaderOptions extends React.Component<
   }
 
   /**
-   * Sets the "isOpen" state to control the dropdown menu
-   */
-  toggleOpen = () =>
-    this.setState({
-      isOpen: !this.state.isOpen
-    });
-
-  /**
-   * Sets "showResolved" state in "App.tsx"
-   */
-  setResolvedState(e: HTMLInputElement) {
-    this.props.showResolvedState(e.checked);
-  }
-
-  /**
-   * Sets the resolve state based on the state of the checkbox
-   */
-  matchCheckBoxState(): void {
-    let checkBox: HTMLInputElement = document.getElementById(
-      'controls'
-    ) as HTMLInputElement;
-
-    checkBox.checked = this.props.showResolved;
-  }
-
-  /**
    * Gets values for the dropdown menu
    *
    * @returns React.ReactNode with dropdown menu items
@@ -265,6 +239,13 @@ export class AppHeaderOptions extends React.Component<
   }
 
   /**
+   * Sets "showResolved" state in "App.tsx"
+   */
+  setResolvedState(e: HTMLInputElement) {
+    this.props.showResolvedState(e.checked);
+  }
+
+  /**
    * Sets "sortState" state in "App.tsx"
    * Adds a name to the Sort by: label
    *
@@ -274,6 +255,26 @@ export class AppHeaderOptions extends React.Component<
   setSortState(state: string) {
     this.toggleOpen();
     this.props.setSortState(state);
+  }
+
+  /**
+   * Sets the "isOpen" state to control the dropdown menu
+   */
+  toggleOpen(): void {
+    this.setState({
+      isOpen: !this.state.isOpen
+    });
+  }
+
+  /**
+   * Sets the resolve state based on the state of the checkbox
+   */
+  matchCheckBoxState(): void {
+    let checkBox: HTMLInputElement = document.getElementById(
+      'controls'
+    ) as HTMLInputElement;
+
+    checkBox.checked = this.props.showResolved;
   }
 
   /**

--- a/src/AppHeaderOptions.tsx
+++ b/src/AppHeaderOptions.tsx
@@ -84,6 +84,9 @@ export class AppHeaderOptions extends React.Component<
     this.toggleOpen = this.toggleOpen.bind(this);
   }
 
+  /**
+   * Checks the state of the component and controlls Show Resolved
+   */
   componentDidMount(): void {
     if (document.getElementById('controls') !== null) {
       this.matchCheckBoxState();
@@ -99,12 +102,14 @@ export class AppHeaderOptions extends React.Component<
     }`;
     return (
       <div className="jp-commenting-header-options-area">
-        <div className={menuClass} style={{ marginTop: '30px' }}>
-          {this.getSortItems()}
-        </div>
         <div style={this.styles.optionBar}>
           {this.getCheckbox()}
           {this.getDropdown()}
+        </div>
+        <div
+          style={this.styles['jp-commenting-header-options-dropdown-menu-area']}
+        >
+          <div className={menuClass}>{this.getSortItems()}</div>
         </div>
       </div>
     );
@@ -302,6 +307,7 @@ export class AppHeaderOptions extends React.Component<
       height: '24px',
       display: 'flex',
       flexDirection: 'row' as 'row',
+      paddingRight: '8px',
       width: '50%',
       minWidth: '50px',
       flexShrink: 1
@@ -338,7 +344,6 @@ export class AppHeaderOptions extends React.Component<
       display: 'flex',
       flexDirection: 'row' as 'row',
       borderLeft: '1px solid var(--jp-border-color1)',
-      marginLeft: '8px',
       width: '50%',
       minWidth: '50px',
       flexShrink: 1
@@ -374,6 +379,7 @@ export class AppHeaderOptions extends React.Component<
       width: '40px',
       minWidth: '40px'
     },
+    'jp-commenting-header-options-dropdown-menu-area': {},
     'jp-commenting-header-options-dropdown-button': {
       minWidth: '40px',
       minHeight: '24px',

--- a/src/AppHeaderOptions.tsx
+++ b/src/AppHeaderOptions.tsx
@@ -24,9 +24,29 @@ interface IAppHeaderOptionsProps {
    * @type boolean
    */
   cardExpanded: boolean;
-  header: string;
+  /**
+   * Current target name
+   *
+   * @type string
+   */
+  target: string;
+  /**
+   * Tracks if the current open thread had cards
+   *
+   * @type boolean
+   */
   hasThreads: boolean;
+  /**
+   * Tracks when to show resolved threads
+   *
+   * @type boolean
+   */
   showResolved: boolean;
+  /**
+   * String that tracks what to sort by
+   *
+   * @type string
+   */
   sortState: string;
 }
 
@@ -40,7 +60,6 @@ interface IAppHeaderOptionsState {
    * @type boolean
    */
   isOpen: boolean;
-  showResolved: boolean;
 }
 
 /**
@@ -58,7 +77,7 @@ export class AppHeaderOptions extends React.Component<
   constructor(props: IAppHeaderOptionsProps) {
     super(props);
 
-    this.state = { isOpen: false, showResolved: false };
+    this.state = { isOpen: false };
 
     this.setResolvedState = this.setResolvedState.bind(this);
     this.matchCheckBoxState = this.matchCheckBoxState.bind(this);
@@ -90,7 +109,12 @@ export class AppHeaderOptions extends React.Component<
     );
   }
 
-  renderCheckbox() {
+  /**
+   * Renders the checkbox and label
+   *
+   * @return React.ReactNode
+   */
+  renderCheckbox(): React.ReactNode {
     return (
       <div
         style={this.styles['jp-commenting-header-options-showResolved-area']}
@@ -103,7 +127,7 @@ export class AppHeaderOptions extends React.Component<
           <label
             style={
               this.props.cardExpanded ||
-              this.props.header === undefined ||
+              this.props.target === undefined ||
               !this.props.hasThreads
                 ? this.styles[
                     'jp-commenting-header-options-showResolved-label-disable'
@@ -134,7 +158,7 @@ export class AppHeaderOptions extends React.Component<
             className={'bp3-checkbox'}
             disabled={
               this.props.cardExpanded ||
-              this.props.header === undefined ||
+              this.props.target === undefined ||
               !this.props.hasThreads
             }
           />
@@ -143,7 +167,12 @@ export class AppHeaderOptions extends React.Component<
     );
   }
 
-  renderDropdown() {
+  /**
+   * Renders the dropdown menu and label
+   *
+   * @return React.ReactNode
+   */
+  renderDropdown(): React.ReactNode {
     return (
       <div
         style={this.styles['jp-commenting-header-options-dropdown-area']}
@@ -157,7 +186,7 @@ export class AppHeaderOptions extends React.Component<
           <label
             style={
               this.props.cardExpanded ||
-              this.props.header === undefined ||
+              this.props.target === undefined ||
               !this.props.hasThreads
                 ? this.styles[
                     'jp-commenting-header-options-dropdown-label-disabled'
@@ -190,6 +219,7 @@ export class AppHeaderOptions extends React.Component<
     this.setState({
       isOpen: !this.state.isOpen
     });
+
   /**
    * Sets "showResolved" state in "App.tsx"
    */
@@ -197,6 +227,9 @@ export class AppHeaderOptions extends React.Component<
     this.props.showResolvedState(e.checked);
   }
 
+  /**
+   * Sets the resolve state based on the state of the checkbox
+   */
   matchCheckBoxState(): void {
     let checkBox: HTMLInputElement = document.getElementById(
       'controls'
@@ -207,8 +240,6 @@ export class AppHeaderOptions extends React.Component<
 
   /**
    * Gets values for the dropdown menu
-   *
-   * @callback to setSortState function
    *
    * @returns React.ReactNode with dropdown menu items
    */

--- a/src/AppHeaderOptions.tsx
+++ b/src/AppHeaderOptions.tsx
@@ -81,6 +81,7 @@ export class AppHeaderOptions extends React.Component<
 
     this.setResolvedState = this.setResolvedState.bind(this);
     this.matchCheckBoxState = this.matchCheckBoxState.bind(this);
+    this.toggleOpen = this.toggleOpen.bind(this);
   }
 
   componentDidMount(): void {
@@ -326,7 +327,7 @@ export class AppHeaderOptions extends React.Component<
     },
     'jp-commenting-header-options-showResolved-label-disable': {
       fontSize: 'var(--jp-ui-font-size1)',
-      color: '#e0e0e0'
+      color: 'var(--md-grey-300)'
     },
     'jp-commenting-header-options-showResolved-checkbox-area': {
       alignSelf: 'center',
@@ -365,7 +366,7 @@ export class AppHeaderOptions extends React.Component<
     'jp-commenting-header-options-dropdown-label-disabled': {
       lineHeight: 'normal',
       fontSize: '13px',
-      color: '#e0e0e0'
+      color: 'var(--md-grey-300)'
     },
     'jp-commenting-header-options-dropdown-button-area': {
       display: 'flex',

--- a/src/AppHeaderOptions.tsx
+++ b/src/AppHeaderOptions.tsx
@@ -260,13 +260,13 @@ export class AppHeaderOptions extends React.Component<
    */
   styles = {
     optionBar: {
-      height: '28px',
+      height: '24px',
       display: 'flex',
       flexDirection: 'row' as 'row',
       justifyContent: 'center'
     },
     'jp-commenting-header-options-showResolved-area': {
-      height: '28px',
+      height: '24px',
       display: 'flex',
       flexDirection: 'row' as 'row',
       width: '50%',
@@ -282,7 +282,7 @@ export class AppHeaderOptions extends React.Component<
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
 
-      height: '28px',
+      height: '24px',
       minWidth: '52px',
 
       textAlign: 'right' as 'right',
@@ -301,7 +301,7 @@ export class AppHeaderOptions extends React.Component<
       minWidth: '20px'
     },
     'jp-commenting-header-options-dropdown-area': {
-      height: '28px',
+      height: '24px',
       display: 'flex',
       flexDirection: 'row' as 'row',
       borderLeft: '1px solid var(--jp-border-color1)',
@@ -319,7 +319,7 @@ export class AppHeaderOptions extends React.Component<
       overflow: 'hidden',
       whiteSpace: 'nowrap' as 'nowrap',
 
-      height: '28px',
+      height: '24px',
       paddingLeft: '4px',
       paddingRight: '4px',
       minWidth: '10px',
@@ -337,13 +337,13 @@ export class AppHeaderOptions extends React.Component<
     },
     'jp-commenting-header-options-dropdown-button-area': {
       display: 'flex',
-      height: '28px',
+      height: '24px',
       width: '40px',
       minWidth: '40px'
     },
     'jp-commenting-header-options-dropdown-button': {
       minWidth: '40px',
-      minHeight: '28px',
+      minHeight: '24px',
       backgroundImage: 'var(--jp-icon-caretdown)',
       backgroundRepeat: 'no-repeat',
       backgroundPosition: 'center'

--- a/src/AppHeaderOptions.tsx
+++ b/src/AppHeaderOptions.tsx
@@ -84,7 +84,7 @@ export class AppHeaderOptions extends React.Component<
         </div>
         <div style={this.styles.optionBar}>
           {this.renderCheckbox()}
-          {this.renderDropdownLabel()}
+          {this.renderDropdown()}
         </div>
       </div>
     );
@@ -92,73 +92,93 @@ export class AppHeaderOptions extends React.Component<
 
   renderCheckbox() {
     return (
-      <div style={this.styles.checkboxArea}>
-        <label
-          style={{
-            paddingTop: '5px',
-            paddingRight: '4px',
-            paddingLeft: '4px'
-          }}
-          className={
-            this.props.cardExpanded ||
-            this.props.header === undefined ||
-            !this.props.hasThreads
-              ? 'jp-commenting-header-options-checkbox-label-disable'
-              : 'jp-commenting-header-options-checkbox-label-enable'
-          }
-        >
-          Show Resolved
-        </label>
-        <input
-          type="checkbox"
-          id="controls"
-          onClick={() =>
-            this.setResolvedState(document.getElementById(
-              'controls'
-            ) as HTMLInputElement)
-          }
-          className={'bp3-checkbox jp-commenting-header-options-checkbox'}
-          disabled={
-            this.props.cardExpanded ||
-            this.props.header === undefined ||
-            !this.props.hasThreads
-          }
-        />
-      </div>
-    );
-  }
-
-  renderDropdownLabel() {
-    return (
-      <div style={this.styles.dropdownBox} onClick={this.toggleOpen}>
-        <label
+      <div
+        style={this.styles['jp-commenting-header-options-showResolved-area']}
+      >
+        <div
           style={
-            this.props.cardExpanded ||
-            this.props.header === undefined ||
-            !this.props.hasThreads
-              ? this.styles.dropdownLabelDisabled
-              : this.styles.dropdownLabelEnabled
+            this.styles['jp-commenting-header-options-showResolved-label-area']
           }
         >
-          Sort By:
-        </label>
-        {this.renderDropdownButton()}
+          <label
+            style={
+              this.props.cardExpanded ||
+              this.props.header === undefined ||
+              !this.props.hasThreads
+                ? this.styles[
+                    'jp-commenting-header-options-showResolved-label-disable'
+                  ]
+                : this.styles[
+                    'jp-commenting-header-options-showResolved-label-enable'
+                  ]
+            }
+          >
+            Show Resolved
+          </label>
+        </div>
+        <div
+          style={
+            this.styles[
+              'jp-commenting-header-options-showResolved-checkbox-area'
+            ]
+          }
+        >
+          <input
+            type="checkbox"
+            id="controls"
+            onClick={() =>
+              this.setResolvedState(document.getElementById(
+                'controls'
+              ) as HTMLInputElement)
+            }
+            className={'bp3-checkbox'}
+            disabled={
+              this.props.cardExpanded ||
+              this.props.header === undefined ||
+              !this.props.hasThreads
+            }
+          />
+        </div>
       </div>
     );
   }
 
-  renderDropdownButton() {
+  renderDropdown() {
     return (
-      <div style={this.styles.dropdownButton}>
-        <input
-          type="image"
-          style={this.styles.dropdownButton}
-          src={
-            'https://material.io/tools/icons/static/icons/baseline-arrow_drop_down-24px.svg'
+      <div
+        style={this.styles['jp-commenting-header-options-dropdown-area']}
+        onClick={this.toggleOpen}
+      >
+        <div
+          style={
+            this.styles['jp-commenting-header-options-dropdown-label-area']
           }
-          data-toggle="dropdown"
-          disabled={this.props.header === undefined || !this.props.hasThreads}
-        />
+        >
+          <label
+            style={
+              this.props.cardExpanded ||
+              this.props.header === undefined ||
+              !this.props.hasThreads
+                ? this.styles[
+                    'jp-commenting-header-options-dropdown-label-disabled'
+                  ]
+                : this.styles[
+                    'jp-commenting-header-options-dropdown-label-enabled'
+                  ]
+            }
+          >
+            Sort By:
+          </label>
+        </div>
+        <div
+          style={
+            this.styles['jp-commenting-header-options-dropdown-button-area']
+          }
+        >
+          <span
+            style={this.styles['jp-commenting-header-options-dropdown-button']}
+          />
+        </div>
       </div>
     );
   }
@@ -245,60 +265,88 @@ export class AppHeaderOptions extends React.Component<
       flexDirection: 'row' as 'row',
       justifyContent: 'center'
     },
-    dropdownBox: {
+    'jp-commenting-header-options-showResolved-area': {
       height: '28px',
       display: 'flex',
       flexDirection: 'row' as 'row',
-      borderLeftWidth: '1px',
-      borderLeftStyle: 'solid' as 'solid',
-      borderLeftColor: 'rgb(224, 224, 224)',
+      width: '50%',
+      minWidth: '50px',
+      flexShrink: 1
+    },
+    'jp-commenting-header-options-showResolved-label-area': {
+      display: 'flex',
+      justifyContent: 'center',
+      flexDirection: 'column' as 'column',
+      flexShrink: 1,
+
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+
+      height: '28px',
+      minWidth: '52px',
+
+      textAlign: 'right' as 'right',
+      paddingLeft: '4px'
+    },
+    'jp-commenting-header-options-showResolved-label-enable': {
+      fontSize: 'var(--jp-ui-font-size1)',
+      color: 'var(--jp-ui-font-color1)'
+    },
+    'jp-commenting-header-options-showResolved-label-disable': {
+      fontSize: 'var(--jp-ui-font-size1)',
+      color: '#e0e0e0'
+    },
+    'jp-commenting-header-options-showResolved-checkbox-area': {
+      alignSelf: 'center',
+      minWidth: '20px'
+    },
+    'jp-commenting-header-options-dropdown-area': {
+      height: '28px',
+      display: 'flex',
+      flexDirection: 'row' as 'row',
+      borderLeft: '1px solid var(--jp-border-color1)',
       marginLeft: '8px',
       width: '50%',
       minWidth: '50px',
       flexShrink: 1
     },
-    dropdownLabelEnabled: {
+    'jp-commenting-header-options-dropdown-label-area': {
+      display: 'flex',
+      justifyContent: 'center',
+      flexDirection: 'column' as 'column',
+      flexShrink: 1,
+
       overflow: 'hidden',
-      textOverflow: 'ellipsis',
       whiteSpace: 'nowrap' as 'nowrap',
+
       height: '28px',
+      paddingLeft: '4px',
+      paddingRight: '4px',
+      minWidth: '10px',
+      width: '100%'
+    },
+    'jp-commenting-header-options-dropdown-label-enabled': {
       lineHeight: 'normal',
       fontSize: '13px',
-      paddingTop: '6px',
-      paddingLeft: '4px',
-      paddingRight: '10px',
-      minWidth: '10px',
-      width: '100%',
-      flexShrink: 1
+      color: 'var(--jp-ui-font-color1)'
     },
-    dropdownLabelDisabled: {
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap' as 'nowrap',
-      height: '28px',
+    'jp-commenting-header-options-dropdown-label-disabled': {
       lineHeight: 'normal',
       fontSize: '13px',
-      paddingTop: '6px',
-      paddingLeft: '4px',
-      paddingRight: '10px',
-      minWidth: '10px',
-      width: '100%',
-      color: '#E0E0E0',
-      flexShrink: 1
+      color: '#e0e0e0'
     },
-    dropdownButton: {
+    'jp-commenting-header-options-dropdown-button-area': {
       display: 'flex',
       height: '28px',
       width: '40px',
       minWidth: '40px'
     },
-    checkboxArea: {
-      height: '28px',
-      display: 'flex',
-      flexDirection: 'row' as 'row',
-      width: '50%',
-      minWidth: '50px',
-      flexShrink: 1
+    'jp-commenting-header-options-dropdown-button': {
+      minWidth: '40px',
+      minHeight: '28px',
+      backgroundImage: 'var(--jp-icon-caretdown)',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'center'
     }
   };
 }

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -215,7 +215,7 @@ export class Comment extends React.Component<ICommentProps> {
     },
     'jp-commenting-annotation-name': {
       fontSize: '13px',
-      color: 'var(--jp-ui-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       fontWeight: 'bold' as 'bold',
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
@@ -239,7 +239,7 @@ export class Comment extends React.Component<ICommentProps> {
     },
     'jp-commenting-annotation-timestamp': {
       fontSize: '.7em',
-      color: 'var(--jp-ui-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis'
@@ -263,7 +263,7 @@ export class Comment extends React.Component<ICommentProps> {
     },
     'jp-commenting-annotation': {
       fontSize: '12px',
-      color: 'var(--jp-ui-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       lineHeight: 'normal'
     },
     'jp-commenting-annotation-area-resolved': {

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -31,6 +31,12 @@ interface ICommentProps {
    * @type string
    */
   expanded: boolean;
+  /**
+   * State if thread is resolved
+   *
+   * @type boolean
+   */
+  resolved: boolean;
 }
 
 /**
@@ -52,7 +58,13 @@ export class Comment extends React.Component<ICommentProps> {
   render() {
     return (
       <div>
-        <div style={this.styles['jp-commenting-annotation-upper-area']}>
+        <div
+          style={
+            this.props.resolved
+              ? this.styles['jp-commenting-annotation-upper-area-resolved']
+              : this.styles['jp-commenting-annotation-upper-area']
+          }
+        >
           <div style={this.styles['jp-commenting-annotation-photo-area']}>
             <img
               style={this.styles['jp-commenting-annotation-photo']}
@@ -72,8 +84,20 @@ export class Comment extends React.Component<ICommentProps> {
             </div>
           </div>
         </div>
-        <div style={this.styles['jp-commenting-annotation-area']}>
-          <p style={this.styles['jp-commenting-annotation']}>
+        <div
+          style={
+            this.props.resolved
+              ? this.styles['jp-commenting-annotation-area-resolved']
+              : this.styles['jp-commenting-annotation-area']
+          }
+        >
+          <p
+            style={
+              this.props.resolved
+                ? this.styles['jp-commenting-annotation-resolved']
+                : this.styles['jp-commenting-annotation']
+            }
+          >
             {this.props.context.length >= 125 && !this.props.expanded
               ? this.props.context.slice(0, 125) + '...'
               : this.props.context}
@@ -124,6 +148,13 @@ export class Comment extends React.Component<ICommentProps> {
       boxSizing: 'border-box' as 'border-box',
       padding: '4px',
       background: 'var(--jp-layout-color1)'
+    },
+    'jp-commenting-annotation-upper-area-resolved': {
+      display: 'flex',
+      flexDirection: 'row' as 'row',
+      boxSizing: 'border-box' as 'border-box',
+      padding: '4px',
+      background: 'var(--jp-layout-color2)'
     },
     'jp-commenting-annotation-info-area': {
       display: 'flex',
@@ -183,6 +214,21 @@ export class Comment extends React.Component<ICommentProps> {
     'jp-commenting-annotation': {
       fontSize: '12px',
       color: 'var(--jp-ui-font-color0)',
+      lineHeight: 'normal'
+    },
+    'jp-commenting-annotation-area-resolved': {
+      display: 'flex',
+      maxHeight: '100%',
+      maxWidth: '350px',
+      boxSizing: 'border-box' as 'border-box',
+      paddingBottom: '4px',
+      paddingLeft: '4px',
+      paddingRight: '4px',
+      background: 'var(--jp-layout-color2)'
+    },
+    'jp-commenting-annotation-resolved': {
+      fontSize: '12px',
+      color: 'var(--jp-ui-font-color2)',
       lineHeight: 'normal'
     }
   };

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -57,7 +57,13 @@ export class Comment extends React.Component<ICommentProps> {
    */
   render() {
     return (
-      <div>
+      <div
+        style={
+          this.props.resolved
+            ? this.styles['jp-commenting-annotation-thread-resolved']
+            : this.styles['jp-commenting-annotation-thread']
+        }
+      >
         <div
           style={
             this.props.resolved
@@ -67,18 +73,34 @@ export class Comment extends React.Component<ICommentProps> {
         >
           <div style={this.styles['jp-commenting-annotation-photo-area']}>
             <img
-              style={this.styles['jp-commenting-annotation-photo']}
+              style={
+                this.props.resolved
+                  ? this.styles['jp-commenting-annotation-photo-resolved']
+                  : this.styles['jp-commenting-annotation-photo']
+              }
               src={this.props.photo}
             />
           </div>
           <div style={this.styles['jp-commenting-annotation-info-area']}>
             <div style={this.styles['jp-commenting-annotation-name-area']}>
-              <h1 style={this.styles['jp-commenting-annotation-name']}>
+              <h1
+                style={
+                  this.props.resolved
+                    ? this.styles['jp-commenting-annotation-name-resolved']
+                    : this.styles['jp-commenting-annotation-name']
+                }
+              >
                 {this.props.name}
               </h1>
             </div>
             <div style={this.styles['jp-commenting-annotation-timestamp-area']}>
-              <p style={this.styles['jp-commenting-annotation-timestamp']}>
+              <p
+                style={
+                  this.props.resolved
+                    ? this.styles['jp-commenting-annotation-timestamp-resolved']
+                    : this.styles['jp-commenting-annotation-timestamp']
+                }
+              >
                 {this.timeStampStyle()}
               </p>
             </div>
@@ -142,6 +164,12 @@ export class Comment extends React.Component<ICommentProps> {
    * CSS Styles
    */
   styles = {
+    'jp-commenting-annotation-thread': {
+      background: 'var(--jp-layout-color1)'
+    },
+    'jp-commenting-annotation-thread-resolved': {
+      background: 'var(--jp-layout-color2)'
+    },
     'jp-commenting-annotation-upper-area': {
       display: 'flex',
       flexDirection: 'row' as 'row',
@@ -173,6 +201,12 @@ export class Comment extends React.Component<ICommentProps> {
       width: '2em',
       borderRadius: 'var(--jp-border-radius)'
     },
+    'jp-commenting-annotation-photo-resolved': {
+      height: '2em',
+      width: '2em',
+      opacity: '0.5',
+      borderRadius: 'var(--jp-border-radius)'
+    },
     'jp-commenting-annotation-name-area': {
       display: 'flex',
       flexShrink: 1,
@@ -188,6 +222,15 @@ export class Comment extends React.Component<ICommentProps> {
       textOverflow: 'ellipsis',
       margin: '0px'
     },
+    'jp-commenting-annotation-name-resolved': {
+      fontSize: '13px',
+      color: 'var(--jp-ui-font-color2)',
+      fontWeight: 'bold' as 'bold',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      margin: '0px'
+    },
     'jp-commenting-annotation-timestamp-area': {
       display: 'flex',
       minWidth: '52px',
@@ -197,6 +240,13 @@ export class Comment extends React.Component<ICommentProps> {
     'jp-commenting-annotation-timestamp': {
       fontSize: '.7em',
       color: 'var(--jp-ui-font-color0)',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis'
+    },
+    'jp-commenting-annotation-timestamp-resolved': {
+      fontSize: '.7em',
+      color: 'var(--jp-ui-font-color2)',
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis'

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -73,8 +73,8 @@ export class Comment extends React.Component<ICommentProps> {
           <p
             className={
               this.props.expanded
-                ? '--jp-commenting-annotation-expanded'
-                : '--jp-commenting-annotation-not-expanded'
+                ? 'jp-commenting-annotation-expanded'
+                : 'jp-commenting-annotation-not-expanded'
             }
           >
             {this.props.context.length >= 125 && !this.props.expanded

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -2,29 +2,11 @@ import * as React from 'react';
 
 interface ICommentProps {
   /**
-   * Name of person commenting
-   *
-   * @type string
-   */
-  name: string;
-  /**
    * Actual comment from the user
    *
    * @type string
    */
   context?: string;
-  /**
-   * Time comment was made
-   *
-   * @type string
-   */
-  timestamp: string;
-  /**
-   * Source of the profile picture
-   *
-   * @type string
-   */
-  photo: string;
   /**
    * State if the CommentCard is expanded
    *
@@ -32,11 +14,29 @@ interface ICommentProps {
    */
   expanded: boolean;
   /**
+   * Name of person commenting
+   *
+   * @type string
+   */
+  name: string;
+  /**
+   * Source of the profile picture
+   *
+   * @type string
+   */
+  photo: string;
+  /**
    * State if thread is resolved
    *
    * @type boolean
    */
   resolved: boolean;
+  /**
+   * Time comment was made
+   *
+   * @type string
+   */
+  timestamp: string;
 }
 
 /**
@@ -56,70 +56,66 @@ export class Comment extends React.Component<ICommentProps> {
    * React render function
    */
   render(): React.ReactNode {
-    return (
-      <div
-        style={
-          this.props.resolved
-            ? this.styles['jp-commenting-annotation-thread-resolved']
-            : this.styles['jp-commenting-annotation-thread']
-        }
-      >
+    return this.props.resolved ? (
+      <div style={this.styles['jp-commenting-annotation-thread-resolved']}>
         <div
-          style={
-            this.props.resolved
-              ? this.styles['jp-commenting-annotation-upper-area-resolved']
-              : this.styles['jp-commenting-annotation-upper-area']
-          }
+          style={this.styles['jp-commenting-annotation-upper-area-resolved']}
         >
           <div style={this.styles['jp-commenting-annotation-photo-area']}>
             <img
-              style={
-                this.props.resolved
-                  ? this.styles['jp-commenting-annotation-photo-resolved']
-                  : this.styles['jp-commenting-annotation-photo']
-              }
+              style={this.styles['jp-commenting-annotation-photo-resolved']}
               src={this.props.photo}
             />
           </div>
           <div style={this.styles['jp-commenting-annotation-info-area']}>
             <div style={this.styles['jp-commenting-annotation-name-area']}>
-              <h1
-                style={
-                  this.props.resolved
-                    ? this.styles['jp-commenting-annotation-name-resolved']
-                    : this.styles['jp-commenting-annotation-name']
-                }
-              >
+              <h1 style={this.styles['jp-commenting-annotation-name-resolved']}>
                 {this.props.name}
               </h1>
             </div>
             <div style={this.styles['jp-commenting-annotation-timestamp-area']}>
               <p
                 style={
-                  this.props.resolved
-                    ? this.styles['jp-commenting-annotation-timestamp-resolved']
-                    : this.styles['jp-commenting-annotation-timestamp']
+                  this.styles['jp-commenting-annotation-timestamp-resolved']
                 }
               >
-                {this.timeStampStyle()}
+                {this.getStyledTimeStamp()}
               </p>
             </div>
           </div>
         </div>
-        <div
-          style={
-            this.props.resolved
-              ? this.styles['jp-commenting-annotation-area-resolved']
-              : this.styles['jp-commenting-annotation-area']
-          }
-        >
-          <p
-            style={
-              this.props.resolved
-                ? this.styles['jp-commenting-annotation-resolved']
-                : this.styles['jp-commenting-annotation']
-            }
-          >
+        <div style={this.styles['jp-commenting-annotation-area-resolved']}>
+          <p style={this.styles['jp-commenting-annotation-resolved']}>
+            {this.props.context.length >= 125 && !this.props.expanded
+              ? this.props.context.slice(0, 125) + '...'
+              : this.props.context}
+          </p>
+        </div>
+      </div>
+    ) : (
+      <div style={this.styles['jp-commenting-annotation-thread']}>
+        <div style={this.styles['jp-commenting-annotation-upper-area']}>
+          <div style={this.styles['jp-commenting-annotation-photo-area']}>
+            <img
+              style={this.styles['jp-commenting-annotation-photo']}
+              src={this.props.photo}
+            />
+          </div>
+          <div style={this.styles['jp-commenting-annotation-info-area']}>
+            <div style={this.styles['jp-commenting-annotation-name-area']}>
+              <h1 style={this.styles['jp-commenting-annotation-name']}>
+                {this.props.name}
+              </h1>
+            </div>
+            <div style={this.styles['jp-commenting-annotation-timestamp-area']}>
+              <p style={this.styles['jp-commenting-annotation-timestamp']}>
+                {this.getStyledTimeStamp()}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div style={this.styles['jp-commenting-annotation-area']}>
+          <p style={this.styles['jp-commenting-annotation']}>
             {this.props.context.length >= 125 && !this.props.expanded
               ? this.props.context.slice(0, 125) + '...'
               : this.props.context}
@@ -134,7 +130,7 @@ export class Comment extends React.Component<ICommentProps> {
    *
    * @return - String: time stamp string
    */
-  timeStampStyle(): string {
+  getStyledTimeStamp(): string {
     let serverTimeStamp = new Date(this.props.timestamp);
     let localTimeStamp = serverTimeStamp.toLocaleString();
     let fullDate = localTimeStamp.split(',')[0].split('/');
@@ -207,9 +203,9 @@ export class Comment extends React.Component<ICommentProps> {
       borderRadius: 'var(--jp-border-radius)'
     },
     'jp-commenting-annotation-photo-resolved': {
-      height: '2em',
-      width: '2em',
-      opacity: '0.5',
+      height: '28px',
+      width: '28px',
+      opacity: 0.5,
       borderRadius: 'var(--jp-border-radius)'
     },
     'jp-commenting-annotation-name-area': {

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -137,7 +137,7 @@ export class Comment extends React.Component<ICommentProps> {
     let fullTime = localTimeStamp.split(',')[1].split(':');
     let timeIdentifier = fullTime[2].slice(3).toLowerCase();
 
-    let month: any = {
+    let month: { [key: string]: String } = {
       '1': 'Jan',
       '2': 'Feb',
       '3': 'Mar',

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -55,7 +55,7 @@ export class Comment extends React.Component<ICommentProps> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div
         style={
@@ -129,6 +129,11 @@ export class Comment extends React.Component<ICommentProps> {
     );
   }
 
+  /**
+   * Styles the time stamp
+   *
+   * @return - String: time stamp string
+   */
   timeStampStyle(): string {
     let serverTimeStamp = new Date(this.props.timestamp);
     let localTimeStamp = serverTimeStamp.toLocaleString();

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -51,32 +51,29 @@ export class Comment extends React.Component<ICommentProps> {
    */
   render() {
     return (
-      <div style={this.styles.commentHeader}>
-        <div style={this.styles.upperComment}>
-          <div style={{ paddingTop: '5px', paddingLeft: '6px' }}>
-            <img style={this.styles.photo} src={this.props.photo} />
+      <div>
+        <div style={this.styles['jp-commenting-annotation-upper-area']}>
+          <div style={this.styles['jp-commenting-annotation-photo-area']}>
+            <img
+              style={this.styles['jp-commenting-annotation-photo']}
+              src={this.props.photo}
+            />
           </div>
-          <div style={this.styles.commentInfo}>
-            <div style={this.styles.nameArea}>
-              <h1 style={this.styles.name}>{this.props.name}</h1>
+          <div style={this.styles['jp-commenting-annotation-info-area']}>
+            <div style={this.styles['jp-commenting-annotation-name-area']}>
+              <h1 style={this.styles['jp-commenting-annotation-name']}>
+                {this.props.name}
+              </h1>
             </div>
-            <p style={this.styles.timestamp}>{this.timeStampStyle()}</p>
+            <div style={this.styles['jp-commenting-annotation-timestamp-area']}>
+              <p style={this.styles['jp-commenting-annotation-timestamp']}>
+                {this.timeStampStyle()}
+              </p>
+            </div>
           </div>
         </div>
-        <div
-          style={{
-            paddingLeft: '6px',
-            paddingRight: '10px',
-            paddingTop: '2px'
-          }}
-        >
-          <p
-            className={
-              this.props.expanded
-                ? 'jp-commenting-annotation-expanded'
-                : 'jp-commenting-annotation-not-expanded'
-            }
-          >
+        <div style={this.styles['jp-commenting-annotation-area']}>
+          <p style={this.styles['jp-commenting-annotation']}>
             {this.props.context.length >= 125 && !this.props.expanded
               ? this.props.context.slice(0, 125) + '...'
               : this.props.context}
@@ -121,26 +118,72 @@ export class Comment extends React.Component<ICommentProps> {
    * CSS Styles
    */
   styles = {
-    upperComment: { display: 'flex', flexDirection: 'row' as 'row' },
-    commentHeader: { marginBottom: '10px' },
-    commentInfo: {
-      paddingLeft: '5px',
+    'jp-commenting-annotation-upper-area': {
       display: 'flex',
-      flexDirection: 'column' as 'column'
+      flexDirection: 'row' as 'row',
+      boxSizing: 'border-box' as 'border-box',
+      padding: '4px',
+      background: 'var(--jp-layout-color1)'
     },
-    photo: {
+    'jp-commenting-annotation-info-area': {
+      display: 'flex',
+      flexDirection: 'column' as 'column',
+      flexShrink: 1,
+      minWidth: '52px',
+      width: '100%',
+      paddingLeft: '4px',
+      boxSizing: 'border-box' as 'border-box'
+    },
+    'jp-commenting-annotation-photo-area': {
+      display: 'flex'
+    },
+    'jp-commenting-annotation-photo': {
       height: '2em',
       width: '2em',
-      borderRadius: '2px'
+      borderRadius: 'var(--jp-border-radius)'
     },
-    nameArea: {
-      paddingTop: '8px'
+    'jp-commenting-annotation-name-area': {
+      display: 'flex',
+      flexShrink: 1,
+      minWidth: '52px',
+      boxSizing: 'border-box' as 'border-box'
     },
-    name: {
-      fontSize: '12px',
+    'jp-commenting-annotation-name': {
+      fontSize: '13px',
+      color: 'var(--jp-ui-font-color0)',
       fontWeight: 'bold' as 'bold',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
       margin: '0px'
     },
-    timestamp: { fontSize: '.7em' }
+    'jp-commenting-annotation-timestamp-area': {
+      display: 'flex',
+      minWidth: '52px',
+      flexShrink: 1,
+      boxSizing: 'border-box' as 'border-box'
+    },
+    'jp-commenting-annotation-timestamp': {
+      fontSize: '.7em',
+      color: 'var(--jp-ui-font-color0)',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis'
+    },
+    'jp-commenting-annotation-area': {
+      display: 'flex',
+      maxHeight: '100%',
+      maxWidth: '350px',
+      boxSizing: 'border-box' as 'border-box',
+      paddingBottom: '4px',
+      paddingLeft: '4px',
+      paddingRight: '4px',
+      background: 'var(--jp-layout-color1)'
+    },
+    'jp-commenting-annotation': {
+      fontSize: '12px',
+      color: 'var(--jp-ui-font-color0)',
+      lineHeight: 'normal'
+    }
   };
 }

--- a/src/Comment.tsx
+++ b/src/Comment.tsx
@@ -73,8 +73,8 @@ export class Comment extends React.Component<ICommentProps> {
           <p
             className={
               this.props.expanded
-                ? 'jp-commenting-annotation-expanded'
-                : 'jp-commenting-annotation-not-expanded'
+                ? '--jp-commenting-annotation-expanded'
+                : '--jp-commenting-annotation-not-expanded'
             }
           >
             {this.props.context.length >= 125 && !this.props.expanded

--- a/src/CommentBody.tsx
+++ b/src/CommentBody.tsx
@@ -9,7 +9,7 @@ interface ICommentBodyProps {
    *
    * @type ReactNode[]
    */
-  comments?: React.ReactNode[];
+  comments: React.ReactNode[];
   /**
    * Tracks if card is expanded
    *
@@ -24,7 +24,7 @@ interface ICommentBodyProps {
   resolved: boolean;
 }
 
-const _maxCommentsPerShrinkCard = 3;
+const _maxCommentsPerShrinkThread: number = 3;
 
 /**
  * CommentBody React Component
@@ -42,7 +42,7 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div style={this.styles['jp-commenting-annotation-body-area']}>
         {this.getComments()}
@@ -59,7 +59,7 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
     let items: React.ReactNode;
     if (this.props.comments != null) {
       if (
-        this.props.comments.length <= _maxCommentsPerShrinkCard ||
+        this.props.comments.length <= _maxCommentsPerShrinkThread ||
         this.props.expanded
       ) {
         // Maps each Comment component into an individual div tag

--- a/src/CommentBody.tsx
+++ b/src/CommentBody.tsx
@@ -16,6 +16,12 @@ interface ICommentBodyProps {
    * @type boolean
    */
   expanded: boolean;
+  /**
+   * Tracks if a thread is resolved
+   *
+   * @type boolean
+   */
+  resolved: boolean;
 }
 
 const _maxCommentsPerShrinkCard = 3;
@@ -62,7 +68,15 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
         ));
       } else if (!this.props.expanded) {
         items = (
-          <div style={this.styles['jp-commenting-more-annotations-icon-area']}>
+          <div
+            style={
+              this.props.resolved
+                ? this.styles[
+                    'jp-commenting-more-annotations-icon-area-resolved'
+                  ]
+                : this.styles['jp-commenting-more-annotations-icon-area']
+            }
+          >
             <span
               className={'jp-Icon jp-MoreHorizIcon'}
               style={this.styles['jp-commenting-more-annotations-icon']}
@@ -91,6 +105,9 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
       transform: 'rotate(90deg)'
     },
     'jp-commenting-more-annotations-icon-area': {
+      background: 'var(--jp-layout-color1)'
+    },
+    'jp-commenting-more-annotations-icon-area-resolved': {
       background: 'var(--jp-layout-color2)'
     }
   };

--- a/src/CommentBody.tsx
+++ b/src/CommentBody.tsx
@@ -37,7 +37,11 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
    * React render function
    */
   render() {
-    return <div style={this.styles.commentBodyStyle}>{this.getComments()}</div>;
+    return (
+      <div style={this.styles['jp-commenting-annotation-body-area']}>
+        {this.getComments()}
+      </div>
+    );
   }
 
   /**
@@ -58,10 +62,10 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
         ));
       } else if (!this.props.expanded) {
         items = (
-          <div>
+          <div style={this.styles['jp-commenting-more-annotations-icon-area']}>
             <span
               className={'jp-Icon jp-MoreHorizIcon'}
-              style={this.styles.circles}
+              style={this.styles['jp-commenting-more-annotations-icon']}
             />
             <div>{this.props.comments[this.props.comments.length - 1]}</div>
           </div>
@@ -77,14 +81,17 @@ export class CommentBody extends React.Component<ICommentBodyProps> {
    * CSS styles
    */
   styles = {
-    commentBodyStyle: {
+    'jp-commenting-annotation-body-area': {
       padding: '0px'
     },
-    circles: {
+    'jp-commenting-more-annotations-icon': {
       minWidth: '28px',
       minHeight: '28px',
       backgroundSize: '28px',
       transform: 'rotate(90deg)'
+    },
+    'jp-commenting-more-annotations-icon-area': {
+      background: 'var(--jp-layout-color2)'
     }
   };
 }

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -129,7 +129,7 @@ export class CommentCard extends React.Component<
       <div
         className={
           this.props.checkExpandedCard(this.props.threadId)
-            ? 'jp-commenting-thread-area-disabled'
+            ? 'jp-commenting-thread-area-no-hover'
             : 'jp-commenting-thread-area'
         }
         style={

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -132,9 +132,6 @@ export class CommentCard extends React.Component<
             ? 'jp-commenting-thread-area-no-hover'
             : 'jp-commenting-thread-area'
         }
-        style={
-          this.props.resolved ? this.styles.resolvedCard : this.styles.card
-        }
         onClick={
           !this.props.checkExpandedCard(this.props.threadId)
             ? this.state.shouldExpand
@@ -145,37 +142,23 @@ export class CommentCard extends React.Component<
         onMouseMoveCapture={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
       >
-        <div
-          style={
-            this.props.resolved
-              ? this.styles.resolvedCardHeading
-              : this.styles.cardHeading
-          }
-        >
-          {this.getCommentHeader()}
-        </div>
-        <div
-          style={
-            this.props.resolved
-              ? this.styles.resolvedCardBody
-              : this.styles.cardBody
-          }
-        >
+        <div>{this.getCommentHeader()}</div>
+        <div>
           <CommentBody
             comments={this.getAllComments()}
             expanded={this.props.checkExpandedCard(this.props.threadId)}
           />
         </div>
-        <div style={this.styles.cardFooter}>{this.getCommentFooter()}</div>
+        <div>{this.getCommentFooter()}</div>
       </div>
     );
   }
 
-  handleMouseEnter(e: any): void {
+  handleMouseEnter(): void {
     this.setState({ hover: true });
   }
 
-  handleMouseLeave(e: any): void {
+  handleMouseLeave(): void {
     this.setState({ hover: false });
   }
 
@@ -333,47 +316,4 @@ export class CommentCard extends React.Component<
       );
     }
   }
-
-  /**
-   * CSS styles
-   */
-  styles = {
-    card: { marginTop: '5px', marginBottom: '5px', background: 'white' },
-    resolvedCard: {
-      marginTop: '5px',
-      marginBottom: '5px',
-      background: 'var(--jp-layout-color2)',
-      color: '#4f4f4f'
-    },
-    cardHeading: {
-      display: 'flex' as 'flex',
-      flexDirection: 'column' as 'column',
-      background: 'white',
-      borderBottom: '0px'
-    },
-    cardBody: {
-      display: 'flex' as 'flex',
-      flexDirection: 'column' as 'column',
-      background: 'white',
-      borderBottom: '0px'
-    },
-    cardFooter: {
-      display: 'flex' as 'flex',
-      flexDirection: 'column' as 'column',
-      background: 'white',
-      borderBottom: '0px'
-    },
-    resolvedCardHeading: {
-      display: 'flex' as 'flex',
-      flexDirection: 'column' as 'column',
-      background: 'var(--jp-layout-color2)',
-      borderBottom: '0px'
-    },
-    resolvedCardBody: {
-      display: 'flex' as 'flex',
-      flexDirection: 'column' as 'column',
-      background: 'var(--jp-layout-color2)',
-      borderBottom: '0px'
-    }
-  };
 }

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -15,7 +15,7 @@ interface ICommentCardProps {
    *
    * @type any
    */
-  data?: any;
+  data: any;
   /**
    * Unique string to identify a card
    *
@@ -81,14 +81,24 @@ interface ICommentCardProps {
   /**
    * Path of file used to itemize comment thread to file
    */
-  target?: string;
+  target: string;
 }
 
 /**
  * React States interface
  */
 interface ICommentCardStates {
+  /**
+   * Tracks if mouse is hovering over thread
+   *
+   * @type boolean
+   */
   hover: boolean;
+  /**
+   * Tracks when to expand
+   *
+   * @type boolean
+   */
   shouldExpand: boolean;
 }
 
@@ -124,7 +134,7 @@ export class CommentCard extends React.Component<
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div
         className={
@@ -155,14 +165,25 @@ export class CommentCard extends React.Component<
     );
   }
 
+  /**
+   * Handles state when mouse enters thread area
+   */
   handleMouseEnter(): void {
     this.setState({ hover: true });
   }
 
+  /**
+   * Handles state when mouse leaves thread area
+   */
   handleMouseLeave(): void {
     this.setState({ hover: false });
   }
 
+  /**
+   * Sets the state for should expand
+   *
+   * @param state Type: boolean - sets the state of should expand
+   */
   handleShouldExpand(state: boolean) {
     this.setState({ shouldExpand: state });
   }
@@ -280,7 +301,6 @@ export class CommentCard extends React.Component<
         context={this.props.data.body[0].value}
         timestamp={this.props.data.body[0].created}
         photo={this.props.data.body[0].creator.image}
-        tag={this.props.data.label}
         expanded={this.props.checkExpandedCard(this.props.threadId)}
         resolved={this.props.resolved}
         handleExpand={this.handleExpand}

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -275,6 +275,7 @@ export class CommentCard extends React.Component<
             timestamp={this.props.data.body[key].created}
             photo={this.props.data.body[key].creator.image}
             expanded={this.props.checkExpandedCard(this.props.threadId)}
+            resolved={this.props.resolved}
           />
         );
       }

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -147,6 +147,7 @@ export class CommentCard extends React.Component<
           <CommentBody
             comments={this.getAllComments()}
             expanded={this.props.checkExpandedCard(this.props.threadId)}
+            resolved={this.props.resolved}
           />
         </div>
         <div>{this.getCommentFooter()}</div>

--- a/src/CommentCard.tsx
+++ b/src/CommentCard.tsx
@@ -11,17 +11,34 @@ import { Comment } from './Comment';
  */
 interface ICommentCardProps {
   /**
+   * Function to check if the given cardID is the current expanded card
+   *
+   * @param cardId - string: Card unique id
+   *
+   * @return boolean: true if card is expanded, false if not
+   */
+  checkExpandedCard: (cardId: string) => boolean;
+  /**
+   * Used to check if the threadId passed in has reply box active
+   *
+   * @param threadId Type: string - CommentCard unique id
+   *
+   * @return type: boolean - True if cardId has reply box open, false if not active
+   */
+  checkReplyActiveCard: (cardId: string) => boolean;
+  /**
    * Comment thread data
    *
    * @type any
    */
   data: any;
   /**
-   * Unique string to identify a card
+   * Pushed comment back to MetadataCommentsService
    *
-   * @type string
+   * @param comment Type: string - comment message
+   * @param cardId Type: String - commend card / thread the comment applies to
    */
-  threadId: string;
+  putComment: (threadId: string, value: string) => void;
   /**
    * Is the card resolved
    *
@@ -35,49 +52,27 @@ interface ICommentCardProps {
    */
   setExpandedCard: (cardId: string) => void;
   /**
-   * Function to check if the given cardID is the current expanded card
-   *
-   * @param cardId - string: Card unique id
-   *
-   * @return boolean: true if card is expanded, false if not
-   */
-  checkExpandedCard: (cardId: string) => boolean;
-  /**
    * Sets this.state.replyActiveCard to the passed in cardId
    *
    * @param cardId Type: string - CommentCard unique id
    */
   setReplyActiveCard: (cardId: string) => void;
   /**
-   * Used to check if the cardId passed in has reply box active
-   *
-   * @param cardId Type: string - CommentCard unique id
-   * @return type: boolean - True if cardId has reply box open, false if not active
-   */
-  checkReplyActiveCard: (cardId: string) => boolean;
-  /**
-   * Pushed comment back to MetadataCommentsService
-   *
-   * @param comment Type: string - comment message
-   * @param cardId Type: String - commend card / thread the comment applies to
-   */
-  /**
    * Sets the value of the given key value pair in specific itemId and cardId
    *
    * @param cardId Type: string - id of card to set value on
    * @param key Type: string - key of value to set
-   * @param value Type: sting - value to set to key
+   * @param value Type: boolean - value to set to key
    *
    * @type void function
    */
   setCardValue(target: string, threadId: string, value: boolean): void;
   /**
-   * Pushed comment back to MetadataCommentsService
+   * Unique string to identify a card
    *
-   * @param comment Type: string - comment message
-   * @param cardId Type: String - commend card / thread the comment applies to
+   * @type string
    */
-  putComment: (threadId: string, value: string) => void;
+  threadId: string;
   /**
    * Path of file used to itemize comment thread to file
    */
@@ -118,12 +113,11 @@ export class CommentCard extends React.Component<
     super(props);
     this.state = { hover: false, shouldExpand: true };
 
-    // Functions to bind(this)
     this.handleExpand = this.handleExpand.bind(this);
     this.handleShrink = this.handleShrink.bind(this);
     this.handleReplyOpen = this.handleReplyOpen.bind(this);
     this.handleReplyClose = this.handleReplyClose.bind(this);
-    this.expandAndReply = this.expandAndReply.bind(this);
+    this.handleExpandAndReply = this.handleExpandAndReply.bind(this);
     this.getInput = this.getInput.bind(this);
     this.handleResolve = this.handleResolve.bind(this);
     this.handleMouseEnter = this.handleMouseEnter.bind(this);
@@ -225,19 +219,9 @@ export class CommentCard extends React.Component<
   /**
    * Handles expanding and opening the reply box
    */
-  expandAndReply(): void {
+  handleExpandAndReply(): void {
     this.handleReplyOpen();
     this.handleExpand();
-  }
-
-  /**
-   * Passes comment message to putComment in App.tsx
-   *
-   * @param comment Type: string - comment message
-   */
-  getInput(comment: string): void {
-    this.props.putComment(this.props.threadId, comment);
-    this.handleReplyClose();
   }
 
   /**
@@ -261,6 +245,16 @@ export class CommentCard extends React.Component<
     } else {
       this.handleShrink();
     }
+  }
+
+  /**
+   * Passes comment message to putComment in App.tsx
+   *
+   * @param comment Type: string - comment message
+   */
+  getInput(comment: string): void {
+    this.props.putComment(this.props.threadId, comment);
+    this.handleReplyClose();
   }
 
   /**
@@ -330,7 +324,7 @@ export class CommentCard extends React.Component<
           resolved={this.props.resolved}
           handleReplyOpen={this.handleReplyOpen}
           handleReplyClose={this.handleReplyClose}
-          expandAndReply={this.expandAndReply}
+          expandAndReply={this.handleExpandAndReply}
           getInput={this.getInput}
           handleResolve={this.handleResolve}
         />

--- a/src/CommentFooter.tsx
+++ b/src/CommentFooter.tsx
@@ -92,12 +92,12 @@ export class CommentFooter extends React.Component<
    */
   render() {
     return (
-      <div style={this.styles.footerArea}>
+      <div style={this.styles['jp-commenting-thread-footer-area']}>
         <div
           style={
             this.props.replyActive
-              ? this.styles.inputBoxAreaActive
-              : this.styles.inputBoxAreaNotActive
+              ? this.styles['jp-commenting-thread-footer-input-active']
+              : this.styles['jp-commenting-thread-footer-input-not-active']
           }
         >
           {this.props.expanded && (
@@ -116,7 +116,9 @@ export class CommentFooter extends React.Component<
             />
           )}
         </div>
-        <div style={this.styles.buttonArea}>{this.getButtons()}</div>
+        <div style={this.styles['jp-commenting-thread-footer-button-area']}>
+          {this.getButtons()}
+        </div>
       </div>
     );
   }
@@ -216,23 +218,22 @@ export class CommentFooter extends React.Component<
    * CSS styles
    */
   styles = {
-    footerArea: {
+    'jp-commenting-thread-footer-area': {
       display: 'flex',
       flexDirection: 'column' as 'column',
-      maxHeight: '94px',
       padding: '4px'
     },
-    buttonArea: {
+    'jp-commenting-thread-footer-button-area': {
       display: 'flex',
-      marginTop: '16px'
+      paddingTop: '4px'
     },
-    inputBoxAreaActive: {
+    'jp-commenting-thread-footer-input-active': {
       display: 'flex',
-      height: '60px'
+      height: '72px'
     },
-    inputBoxAreaNotActive: {
+    'jp-commenting-thread-footer-input-not-active': {
       display: 'flex',
-      height: '14px'
+      height: '24px'
     }
   };
 }

--- a/src/CommentFooter.tsx
+++ b/src/CommentFooter.tsx
@@ -11,30 +11,6 @@ interface ICommentFooterProps {
    */
   expanded: boolean;
   /**
-   * Is the card resolved
-   *
-   * @type boolean
-   */
-  resolved: boolean;
-  /**
-   * Tracks if the reply box is active
-   *
-   * @type return function
-   */
-  replyActive: boolean;
-  /**
-   * Function to call to parent component to open the reply box
-   *
-   * @type void
-   */
-  handleReplyOpen: () => void;
-  /**
-   * Function to call to parent component to close the reply box
-   *
-   * @type void
-   */
-  handleReplyClose: () => void;
-  /**
    * Function to call to parent component to handle expanding and opening the reply box
    *
    * @type void
@@ -54,6 +30,30 @@ interface ICommentFooterProps {
    * @type: void
    */
   handleResolve: () => void;
+  /**
+   * Function to call to parent component to close the reply box
+   *
+   * @type void
+   */
+  handleReplyClose: () => void;
+  /**
+   * Function to call to parent component to open the reply box
+   *
+   * @type void
+   */
+  handleReplyOpen: () => void;
+  /**
+   * Tracks if the reply box is active
+   *
+   * @type return function
+   */
+  replyActive: boolean;
+  /**
+   * Is the card resolved
+   *
+   * @type boolean
+   */
+  resolved: boolean;
 }
 
 /**
@@ -129,6 +129,48 @@ export class CommentFooter extends React.Component<
   }
 
   /**
+   * Handles key events
+   *
+   * @param e Type: React.KeyboardEvent - keyboard event
+   */
+  handleKeyPress(e: React.KeyboardEvent): void {
+    if (
+      this.state.commentBox.trim() !== '' &&
+      e.key === 'Enter' &&
+      !e.shiftKey
+    ) {
+      this.handleCommentButton();
+      document.getElementById('commentBox').blur();
+    }
+  }
+
+  /**
+   * Handles when the comment box changes
+   *
+   * @param e Type: React.ChangeEvent<HTMLTextAreaElement> - input box event
+   */
+  handleChangeCommentBox(e: React.ChangeEvent<HTMLTextAreaElement>): void {
+    this.setState({ commentBox: e.target.value });
+  }
+
+  /**
+   * Handles clicking the comment button
+   */
+  handleCommentButton(): void {
+    this.props.getInput(this.state.commentBox);
+    this.setState({ commentBox: '' });
+    this.props.handleReplyClose();
+  }
+
+  /**
+   * Handles states when cancel is pressed
+   */
+  handleCancelButton(): void {
+    this.setState({ commentBox: '' });
+    this.props.handleReplyClose();
+  }
+
+  /**
    * Returns the correct buttons for different state combinations
    *
    * @return Type: React.ReactNode - JSX with buttons
@@ -177,48 +219,6 @@ export class CommentFooter extends React.Component<
         Cancel
       </button>
     );
-  }
-
-  /**
-   * Handles key events
-   *
-   * @param e Type: React.KeyboardEvent - keyboard event
-   */
-  handleKeyPress(e: React.KeyboardEvent): void {
-    if (
-      this.state.commentBox.trim() !== '' &&
-      e.key === 'Enter' &&
-      !e.shiftKey
-    ) {
-      this.handleCommentButton();
-      document.getElementById('commentBox').blur();
-    }
-  }
-
-  /**
-   * Handles when the comment box changes
-   *
-   * @param e Type: React.ChangeEvent<HTMLTextAreaElement> - input box event
-   */
-  handleChangeCommentBox(e: React.ChangeEvent<HTMLTextAreaElement>): void {
-    this.setState({ commentBox: e.target.value });
-  }
-
-  /**
-   * Handles clicking the comment button
-   */
-  handleCommentButton(): void {
-    this.props.getInput(this.state.commentBox);
-    this.setState({ commentBox: '' });
-    this.props.handleReplyClose();
-  }
-
-  /**
-   * Handles states when cancel is pressed
-   */
-  handleCancelButton(): void {
-    this.setState({ commentBox: '' });
-    this.props.handleReplyClose();
   }
 
   /**

--- a/src/CommentFooter.tsx
+++ b/src/CommentFooter.tsx
@@ -25,41 +25,46 @@ interface ICommentFooterProps {
   /**
    * Function to call to parent component to open the reply box
    *
-   * @type VoidFunction
+   * @type void
    */
-  handleReplyOpen: VoidFunction;
+  handleReplyOpen: () => void;
   /**
    * Function to call to parent component to close the reply box
    *
-   * @type VoidFunction
+   * @type void
    */
-  handleReplyClose: VoidFunction;
+  handleReplyClose: () => void;
   /**
    * Function to call to parent component to handle expanding and opening the reply box
    *
-   * @type VoidFunction
+   * @type void
    */
-  expandAndReply: VoidFunction;
+  expandAndReply: () => void;
   /**
    * Passes comment message to putComment in App.tsx
    *
    * @param comment Type: string - comment message
    *
-   * @type void function
+   * @type void
    */
   getInput: (comment: string) => void;
   /**
    * Reverses resolve state
    *
-   * @type: void function
+   * @type: void
    */
-  handleResolve: VoidFunction;
+  handleResolve: () => void;
 }
 
 /**
  * React States interface
  */
 interface ICommentFooterStates {
+  /**
+   * Tracks what is in the text area
+   *
+   * @type string
+   */
   commentBox: string;
 }
 
@@ -90,7 +95,7 @@ export class CommentFooter extends React.Component<
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div style={this.styles['jp-commenting-thread-footer-area']}>
         <div
@@ -177,9 +182,9 @@ export class CommentFooter extends React.Component<
   /**
    * Handles key events
    *
-   * @param e Type: ? - keyboard event
+   * @param e Type: React.KeyboardEvent - keyboard event
    */
-  handleKeyPress(e: any): void {
+  handleKeyPress(e: React.KeyboardEvent): void {
     if (
       this.state.commentBox.trim() !== '' &&
       e.key === 'Enter' &&
@@ -190,13 +195,12 @@ export class CommentFooter extends React.Component<
     }
   }
 
-  // TODO: Get correct type
   /**
    * Handles when the comment box changes
    *
-   * @param e Type: any - input box event
+   * @param e Type: React.ChangeEvent<HTMLTextAreaElement> - input box event
    */
-  handleChangeCommentBox(e: any): void {
+  handleChangeCommentBox(e: React.ChangeEvent<HTMLTextAreaElement>): void {
     this.setState({ commentBox: e.target.value });
   }
 
@@ -209,6 +213,9 @@ export class CommentFooter extends React.Component<
     this.props.handleReplyClose();
   }
 
+  /**
+   * Handles states when cancel is pressed
+   */
   handleCancelButton(): void {
     this.setState({ commentBox: '' });
     this.props.handleReplyClose();

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -219,7 +219,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
       flexDirection: 'row' as 'row',
       boxSizing: 'border-box' as 'border-box',
       padding: '4px',
-      background: 'var(--jp-layout-color0)'
+      background: 'var(--jp-layout-color1)'
     },
     'jp-commenting-thread-header-info-area': {
       display: 'flex',
@@ -271,8 +271,10 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
       maxHeight: '100%',
       maxWidth: '350px',
       boxSizing: 'border-box' as 'border-box',
-      padding: '4px',
-      background: 'var(--jp-layout-color0)'
+      paddingBottom: '4px',
+      paddingLeft: '4px',
+      paddingRight: '4px',
+      background: 'var(--jp-layout-color1)'
     },
     'jp-commenting-annotation': {
       fontSize: 'var(--jp-content-font-size0)',

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -87,7 +87,13 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
   render() {
     return (
       <div>
-        <div style={this.styles['jp-commenting-thread-header-upper-area']}>
+        <div
+          style={
+            this.props.resolved
+              ? this.styles['jp-commenting-thread-header-upper-area-resolved']
+              : this.styles['jp-commenting-thread-header-upper-area']
+          }
+        >
           <div style={this.styles['jp-commenting-thread-header-photo-area']}>
             <img
               style={this.styles['jp-commenting-thread-header-photo']}
@@ -112,8 +118,20 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
             {this.getCornerButton()}
           </div>
         </div>
-        <div style={this.styles['jp-commenting-annotation-area']}>
-          <p style={this.styles['jp-commenting-annotation']}>
+        <div
+          style={
+            this.props.resolved
+              ? this.styles['jp-commenting-annotation-area-resolved']
+              : this.styles['jp-commenting-annotation-area']
+          }
+        >
+          <p
+            style={
+              this.props.resolved
+                ? this.styles['jp-commenting-annotation-resolved']
+                : this.styles['jp-commenting-annotation']
+            }
+          >
             {this.props.context.length >= 125 && !this.props.expanded
               ? this.props.context.slice(0, 125) + '...'
               : this.props.context}
@@ -221,6 +239,13 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
       padding: '4px',
       background: 'var(--jp-layout-color1)'
     },
+    'jp-commenting-thread-header-upper-area-resolved': {
+      display: 'flex',
+      flexDirection: 'row' as 'row',
+      boxSizing: 'border-box' as 'border-box',
+      padding: '4px',
+      background: 'var(--jp-layout-color2)'
+    },
     'jp-commenting-thread-header-info-area': {
       display: 'flex',
       flexDirection: 'column' as 'column',
@@ -279,6 +304,21 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     'jp-commenting-annotation': {
       fontSize: 'var(--jp-content-font-size0)',
       color: 'var(--jp-ui-font-color0)',
+      lineHeight: 'normal'
+    },
+    'jp-commenting-annotation-area-resolved': {
+      display: 'flex',
+      maxHeight: '100%',
+      maxWidth: '350px',
+      boxSizing: 'border-box' as 'border-box',
+      paddingBottom: '4px',
+      paddingLeft: '4px',
+      paddingRight: '4px',
+      background: 'var(--jp-layout-color2)'
+    },
+    'jp-commenting-annotation-resolved': {
+      fontSize: 'var(--jp-content-font-size0)',
+      color: 'var(--jp-ui-font-color2)',
       lineHeight: 'normal'
     },
     'jp-commenting-thread-header-button-area': {

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -247,7 +247,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     let fullTime = localTimeStamp.split(',')[1].split(':');
     let timeIdentifier = fullTime[2].slice(3).toLowerCase();
 
-    let month: any = {
+    let month: { [key: string]: String } = {
       '1': 'Jan',
       '2': 'Feb',
       '3': 'Mar',

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -5,24 +5,6 @@ import * as React from 'react';
  */
 interface ICommentHeaderProps {
   /**
-   * Person name of comment
-   *
-   * @type string
-   */
-  name: string;
-  /**
-   * Time stamp of comment
-   *
-   * @type string
-   */
-  timestamp: string;
-  /**
-   * URL to Person photo to display
-   *
-   * @type string
-   */
-  photo: string;
-  /**
    * Text comment to display
    *
    * @type string
@@ -35,29 +17,11 @@ interface ICommentHeaderProps {
    */
   expanded: boolean;
   /**
-   * Is the card resolved
-   *
-   * @type boolean
-   */
-  resolved: boolean;
-  /**
-   * Tracks if cursor is hovering over card
-   *
-   * @type boolean
-   */
-  hover: boolean;
-  /**
    * Function to handle the CommentCard expanding
    *
    * @type void
    */
   handleExpand: () => void;
-  /**
-   * Function to handle the CommentCard shrinking
-   *
-   * @type void
-   */
-  handleShrink: () => void;
   /**
    * Reverses resolve state
    *
@@ -70,6 +34,42 @@ interface ICommentHeaderProps {
    * @type void
    */
   handleShouldExpand: (state: boolean) => void;
+  /**
+   * Function to handle the CommentCard shrinking
+   *
+   * @type void
+   */
+  handleShrink: () => void;
+  /**
+   * Tracks if cursor is hovering over card
+   *
+   * @type boolean
+   */
+  hover: boolean;
+  /**
+   * Person name of comment
+   *
+   * @type string
+   */
+  name: string;
+  /**
+   * URL to Person photo to display
+   *
+   * @type string
+   */
+  photo: string;
+  /**
+   * Is the card resolved
+   *
+   * @type boolean
+   */
+  resolved: boolean;
+  /**
+   * Time stamp of comment
+   *
+   * @type string
+   */
+  timestamp: string;
 }
 
 /**
@@ -89,39 +89,21 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
    * React render function
    */
   render(): React.ReactNode {
-    return (
-      <div
-        style={
-          this.props.resolved
-            ? this.styles['jp-commenting-thread-header-resolved']
-            : this.styles['jp-commenting-thread-header']
-        }
-      >
+    return this.props.resolved ? (
+      <div style={this.styles['jp-commenting-thread-header-resolved']}>
         <div
-          style={
-            this.props.resolved
-              ? this.styles['jp-commenting-thread-header-upper-area-resolved']
-              : this.styles['jp-commenting-thread-header-upper-area']
-          }
+          style={this.styles['jp-commenting-thread-header-upper-area-resolved']}
         >
           <div style={this.styles['jp-commenting-thread-header-photo-area']}>
             <img
-              style={
-                this.props.resolved
-                  ? this.styles['jp-commenting-thread-header-photo-resolved']
-                  : this.styles['jp-commenting-thread-header-photo']
-              }
+              style={this.styles['jp-commenting-thread-header-photo-resolved']}
               src={this.props.photo}
             />
           </div>
           <div style={this.styles['jp-commenting-thread-header-info-area']}>
             <div style={this.styles['jp-commenting-thread-header-name-area']}>
               <h1
-                style={
-                  this.props.resolved
-                    ? this.styles['jp-commenting-thread-header-name-resolved']
-                    : this.styles['jp-commenting-thread-header-name']
-                }
+                style={this.styles['jp-commenting-thread-header-name-resolved']}
               >
                 {this.props.name}
               </h1>
@@ -131,14 +113,10 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
             >
               <p
                 style={
-                  this.props.resolved
-                    ? this.styles[
-                        'jp-commenting-thread-header-timestamp-resolved'
-                      ]
-                    : this.styles['jp-commenting-thread-header-timestamp']
+                  this.styles['jp-commenting-thread-header-timestamp-resolved']
                 }
               >
-                {this.timeStampStyle()}
+                {this.getStyledTimeStamp()}
               </p>
             </div>
           </div>
@@ -146,20 +124,43 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
             {this.getCornerButton()}
           </div>
         </div>
-        <div
-          style={
-            this.props.resolved
-              ? this.styles['jp-commenting-annotation-area-resolved']
-              : this.styles['jp-commenting-annotation-area']
-          }
-        >
-          <p
-            style={
-              this.props.resolved
-                ? this.styles['jp-commenting-annotation-resolved']
-                : this.styles['jp-commenting-annotation']
-            }
-          >
+        <div style={this.styles['jp-commenting-annotation-area-resolved']}>
+          <p style={this.styles['jp-commenting-annotation-resolved']}>
+            {this.props.context.length >= 125 && !this.props.expanded
+              ? this.props.context.slice(0, 125) + '...'
+              : this.props.context}
+          </p>
+        </div>
+      </div>
+    ) : (
+      <div style={this.styles['jp-commenting-thread-header']}>
+        <div style={this.styles['jp-commenting-thread-header-upper-area']}>
+          <div style={this.styles['jp-commenting-thread-header-photo-area']}>
+            <img
+              style={this.styles['jp-commenting-thread-header-photo']}
+              src={this.props.photo}
+            />
+          </div>
+          <div style={this.styles['jp-commenting-thread-header-info-area']}>
+            <div style={this.styles['jp-commenting-thread-header-name-area']}>
+              <h1 style={this.styles['jp-commenting-thread-header-name']}>
+                {this.props.name}
+              </h1>
+            </div>
+            <div
+              style={this.styles['jp-commenting-thread-header-timestamp-area']}
+            >
+              <p style={this.styles['jp-commenting-thread-header-timestamp']}>
+                {this.getStyledTimeStamp()}
+              </p>
+            </div>
+          </div>
+          <div style={this.styles['jp-commenting-thread-header-button-area']}>
+            {this.getCornerButton()}
+          </div>
+        </div>
+        <div style={this.styles['jp-commenting-annotation-area']}>
+          <p style={this.styles['jp-commenting-annotation']}>
             {this.props.context.length >= 125 && !this.props.expanded
               ? this.props.context.slice(0, 125) + '...'
               : this.props.context}
@@ -239,7 +240,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
    *
    * @type string
    */
-  timeStampStyle(): string {
+  getStyledTimeStamp(): string {
     let serverTimeStamp = new Date(this.props.timestamp);
     let localTimeStamp = serverTimeStamp.toLocaleString();
     let fullDate = localTimeStamp.split(',')[0].split('/');
@@ -315,7 +316,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     'jp-commenting-thread-header-photo-resolved': {
       height: '36px',
       width: '36px',
-      opacity: '0.5',
+      opacity: 0.5,
       borderRadius: 'var(--jp-border-radius)'
     },
     'jp-commenting-thread-header-name-area': {

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -87,32 +87,33 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
   render() {
     return (
       <div>
-        <div style={this.styles.upperHeader}>
-          <div style={{ paddingLeft: '5px', paddingTop: '5px' }}>
-            <img style={this.styles.photo} src={this.props.photo} />
+        <div style={this.styles['jp-commenting-thread-header-upper-area']}>
+          <div style={this.styles['jp-commenting-thread-header-photo-area']}>
+            <img
+              style={this.styles['jp-commenting-thread-header-photo']}
+              src={this.props.photo}
+            />
           </div>
-          <div style={this.styles.commentInfo}>
-            <div style={this.styles.nameArea}>
-              <h1 style={this.styles.name}>{this.props.name}</h1>
+          <div style={this.styles['jp-commenting-thread-header-info-area']}>
+            <div style={this.styles['jp-commenting-thread-header-name-area']}>
+              <h1 style={this.styles['jp-commenting-thread-header-name']}>
+                {this.props.name}
+              </h1>
             </div>
-            <p style={this.styles.timestamp}>{this.timeStampStyle()}</p>
+            <div
+              style={this.styles['jp-commenting-thread-header-timestamp-area']}
+            >
+              <p style={this.styles['jp-commenting-thread-header-timestamp']}>
+                {this.timeStampStyle()}
+              </p>
+            </div>
           </div>
-          {this.shouldRenderCornerButtons()}
+          <div style={this.styles['jp-commenting-thread-header-button-area']}>
+            {this.getCornerButton()}
+          </div>
         </div>
-        <div
-          style={{
-            paddingLeft: '4px',
-            paddingRight: '8px',
-            paddingTop: '4px'
-          }}
-        >
-          <p
-            className={
-              this.props.expanded
-                ? 'jp-commenting-annotation-expanded'
-                : 'jp-commenting-annotation-not-expanded'
-            }
-          >
+        <div style={this.styles['jp-commenting-annotation-area']}>
+          <p style={this.styles['jp-commenting-annotation']}>
             {this.props.context.length >= 125 && !this.props.expanded
               ? this.props.context.slice(0, 125) + '...'
               : this.props.context}
@@ -131,7 +132,6 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     return (
       <button
         className="jp-commenting-button-blue"
-        style={this.styles.resolveButton}
         type="button"
         onClick={this.props.handleResolve}
         onMouseEnter={() => this.props.handleShouldExpand(false)}
@@ -146,7 +146,6 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     return (
       <button
         className="jp-commenting-button-blue jp-commenting-button-resolved"
-        style={this.styles.resolveButton}
         type="button"
         onClick={this.props.handleResolve}
         onMouseEnter={() => this.props.handleShouldExpand(false)}
@@ -157,7 +156,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     );
   }
 
-  shouldRenderCornerButtons(): React.ReactNode {
+  getCornerButton(): React.ReactNode {
     if (this.props.hover && !this.props.expanded) {
       return (
         <div>
@@ -215,32 +214,77 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
    * CSS styles
    */
   styles = {
-    upperHeader: { display: 'flex', flexDirection: 'row' as 'row' },
-    resolveButton: {
-      marginRight: '5px',
-      marginTop: '5px',
-      fontSize: 'var(--jp-content-font-size0)',
-      fontFamily: 'var(--jp-content-font-family)'
-    },
-    commentInfo: {
-      paddingLeft: '5px',
+    'jp-commenting-thread-header-upper-area': {
       display: 'flex',
-      flexGrow: 2,
-      flexDirection: 'column' as 'column'
+      flexDirection: 'row' as 'row',
+      boxSizing: 'border-box' as 'border-box',
+      padding: '4px',
+      background: 'var(--jp-layout-color0)'
     },
-    photo: {
+    'jp-commenting-thread-header-info-area': {
+      display: 'flex',
+      flexDirection: 'column' as 'column',
+      flexShrink: 1,
+      minWidth: '52px',
+      width: '100%',
+      paddingLeft: '4px',
+      boxSizing: 'border-box' as 'border-box'
+    },
+    'jp-commenting-thread-header-photo-area': {
+      display: 'flex'
+    },
+    'jp-commenting-thread-header-photo': {
       height: '36px',
       width: '36px',
-      borderRadius: '2px'
+      borderRadius: 'var(--jp-border-radius)'
     },
-    nameArea: {
-      paddingTop: '11px'
+    'jp-commenting-thread-header-name-area': {
+      display: 'flex',
+      flexShrink: 1,
+      minWidth: '52px',
+      boxSizing: 'border-box' as 'border-box'
     },
-    name: {
+    'jp-commenting-thread-header-name': {
       fontSize: '13px',
+      color: 'var(--jp-ui-font-color0)',
       fontWeight: 'bold' as 'bold',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
       margin: '0px'
     },
-    timestamp: { fontSize: '.7em' }
+    'jp-commenting-thread-header-timestamp-area': {
+      display: 'flex',
+      minWidth: '52px',
+      flexShrink: 1,
+      boxSizing: 'border-box' as 'border-box'
+    },
+    'jp-commenting-thread-header-timestamp': {
+      fontSize: 'var(--jp-ui-font-size0)',
+      color: 'var(--jp-ui-font-color0)',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis'
+    },
+    'jp-commenting-annotation-area': {
+      display: 'flex',
+      maxHeight: '100%',
+      maxWidth: '350px',
+      boxSizing: 'border-box' as 'border-box',
+      padding: '4px',
+      background: 'var(--jp-layout-color0)'
+    },
+    'jp-commenting-annotation': {
+      fontSize: 'var(--jp-content-font-size0)',
+      color: 'var(--jp-ui-font-color0)',
+      lineHeight: 'normal'
+    },
+    'jp-commenting-thread-header-button-area': {
+      display: 'flex',
+      minWidth: '72px',
+      paddingRight: '4px',
+      paddingLeft: '8px',
+      boxSizing: 'border-box' as 'border-box'
+    }
   };
 }

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -86,7 +86,13 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
    */
   render() {
     return (
-      <div>
+      <div
+        style={
+          this.props.resolved
+            ? this.styles['jp-commenting-thread-header-resolved']
+            : this.styles['jp-commenting-thread-header']
+        }
+      >
         <div
           style={
             this.props.resolved
@@ -96,20 +102,38 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
         >
           <div style={this.styles['jp-commenting-thread-header-photo-area']}>
             <img
-              style={this.styles['jp-commenting-thread-header-photo']}
+              style={
+                this.props.resolved
+                  ? this.styles['jp-commenting-thread-header-photo-resolved']
+                  : this.styles['jp-commenting-thread-header-photo']
+              }
               src={this.props.photo}
             />
           </div>
           <div style={this.styles['jp-commenting-thread-header-info-area']}>
             <div style={this.styles['jp-commenting-thread-header-name-area']}>
-              <h1 style={this.styles['jp-commenting-thread-header-name']}>
+              <h1
+                style={
+                  this.props.resolved
+                    ? this.styles['jp-commenting-thread-header-name-resolved']
+                    : this.styles['jp-commenting-thread-header-name']
+                }
+              >
                 {this.props.name}
               </h1>
             </div>
             <div
               style={this.styles['jp-commenting-thread-header-timestamp-area']}
             >
-              <p style={this.styles['jp-commenting-thread-header-timestamp']}>
+              <p
+                style={
+                  this.props.resolved
+                    ? this.styles[
+                        'jp-commenting-thread-header-timestamp-resolved'
+                      ]
+                    : this.styles['jp-commenting-thread-header-timestamp']
+                }
+              >
                 {this.timeStampStyle()}
               </p>
             </div>
@@ -232,6 +256,12 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
    * CSS styles
    */
   styles = {
+    'jp-commenting-thread-header': {
+      background: 'var(--jp-layout-color1)'
+    },
+    'jp-commenting-thread-header-resolved': {
+      background: 'var(--jp-layout-color2)'
+    },
     'jp-commenting-thread-header-upper-area': {
       display: 'flex',
       flexDirection: 'row' as 'row',
@@ -263,6 +293,12 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
       width: '36px',
       borderRadius: 'var(--jp-border-radius)'
     },
+    'jp-commenting-thread-header-photo-resolved': {
+      height: '36px',
+      width: '36px',
+      opacity: '0.5',
+      borderRadius: 'var(--jp-border-radius)'
+    },
     'jp-commenting-thread-header-name-area': {
       display: 'flex',
       flexShrink: 1,
@@ -278,6 +314,15 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
       textOverflow: 'ellipsis',
       margin: '0px'
     },
+    'jp-commenting-thread-header-name-resolved': {
+      fontSize: '13px',
+      color: 'var(--jp-ui-font-color2)',
+      fontWeight: 'bold' as 'bold',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      margin: '0px'
+    },
     'jp-commenting-thread-header-timestamp-area': {
       display: 'flex',
       minWidth: '52px',
@@ -287,6 +332,13 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     'jp-commenting-thread-header-timestamp': {
       fontSize: 'var(--jp-ui-font-size0)',
       color: 'var(--jp-ui-font-color0)',
+      whiteSpace: 'nowrap' as 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis'
+    },
+    'jp-commenting-thread-header-timestamp-resolved': {
+      fontSize: 'var(--jp-ui-font-size0)',
+      color: 'var(--jp-ui-font-color2)',
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis'

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -27,13 +27,7 @@ interface ICommentHeaderProps {
    *
    * @type string
    */
-  context?: string;
-  /**
-   * Tag to display in the header
-   *
-   * @type string
-   */
-  tag?: string;
+  context: string;
   /**
    * Tracks the state if the card is expanded
    *
@@ -47,24 +41,34 @@ interface ICommentHeaderProps {
    */
   resolved: boolean;
   /**
+   * Tracks if cursor is hovering over card
+   *
+   * @type boolean
+   */
+  hover: boolean;
+  /**
    * Function to handle the CommentCard expanding
    *
-   * @type VoidFunction
+   * @type void
    */
-  handleExpand: VoidFunction;
+  handleExpand: () => void;
   /**
    * Function to handle the CommentCard shrinking
    *
-   * @type VoidFunction
+   * @type void
    */
-  handleShrink: VoidFunction;
+  handleShrink: () => void;
   /**
    * Reverses resolve state
    *
-   * @type: void function
+   * @type: void
    */
-  handleResolve: VoidFunction;
-  hover: boolean;
+  handleResolve: () => void;
+  /**
+   * Handles expanding
+   *
+   * @type void
+   */
   handleShouldExpand: (state: boolean) => void;
 }
 
@@ -84,7 +88,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div
         style={
@@ -184,6 +188,11 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     );
   }
 
+  /**
+   * Creates and returns re-open button
+   *
+   * @type Type: React.ReactNode
+   */
   getReopenButton(): React.ReactNode {
     return (
       <button
@@ -198,6 +207,11 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     );
   }
 
+  /**
+   * Creates and returns the corner button based on states
+   *
+   * @type React.ReactNode
+   */
   getCornerButton(): React.ReactNode {
     if (this.props.hover && !this.props.expanded) {
       return (
@@ -220,6 +234,11 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     }
   }
 
+  /**
+   * Styles and returns timestamp
+   *
+   * @type string
+   */
   timeStampStyle(): string {
     let serverTimeStamp = new Date(this.props.timestamp);
     let localTimeStamp = serverTimeStamp.toLocaleString();

--- a/src/CommentHeader.tsx
+++ b/src/CommentHeader.tsx
@@ -307,7 +307,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     },
     'jp-commenting-thread-header-name': {
       fontSize: '13px',
-      color: 'var(--jp-ui-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       fontWeight: 'bold' as 'bold',
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
@@ -331,7 +331,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     },
     'jp-commenting-thread-header-timestamp': {
       fontSize: 'var(--jp-ui-font-size0)',
-      color: 'var(--jp-ui-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       whiteSpace: 'nowrap' as 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis'
@@ -355,7 +355,7 @@ export class CommentHeader extends React.Component<ICommentHeaderProps> {
     },
     'jp-commenting-annotation': {
       fontSize: 'var(--jp-content-font-size0)',
-      color: 'var(--jp-ui-font-color0)',
+      color: 'var(--jp-ui-font-color1)',
       lineHeight: 'normal'
     },
     'jp-commenting-annotation-area-resolved': {

--- a/src/NewThreadCard.tsx
+++ b/src/NewThreadCard.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
+import { IPerson } from './app';
+
 interface INewThreadCardProps {
   /**
    * Creator object
    *
-   * @type any
+   * @type IPerson
    */
-  creator: any;
+  creator: IPerson;
   /**
    * Function to put comment back to server
    *
@@ -173,8 +175,8 @@ export class NewThreadCard extends React.Component<
     'jp-commenting-text-input-area': {
       display: 'flex',
       padding: '4px',
-      maxWidth: '95%',
-      minHeight: '80px'
+      width: '95%',
+      height: '80px'
     },
     'jp-commenting-new-thread-name': {
       fontSize: 'var(--jp-ui-font-size1)',

--- a/src/NewThreadCard.tsx
+++ b/src/NewThreadCard.tsx
@@ -18,6 +18,11 @@ interface INewThreadCardProps {
    * @type void function
    */
   setNewThreadActive: (state: boolean) => void;
+  /**
+   * Creator object
+   *
+   * @type any
+   */
   creator: any;
 }
 
@@ -52,7 +57,7 @@ export class NewThreadCard extends React.Component<
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div style={this.styles['jp-commenting-new-thread-area']}>
         <div style={this.styles['jp-commenting-new-thread-name-area']}>
@@ -81,10 +86,18 @@ export class NewThreadCard extends React.Component<
     );
   }
 
-  componentDidMount() {
+  /**
+   * Called when a component is mounted
+   */
+  componentDidMount(): void {
     document.getElementById('commentBox').focus();
   }
 
+  /**
+   * Creates and returns the comment button
+   *
+   * @return Type: React.ReactNode - JSX button
+   */
   getCommentButton(): React.ReactNode {
     return (
       <button
@@ -98,6 +111,11 @@ export class NewThreadCard extends React.Component<
     );
   }
 
+  /**
+   * Creates and returns the cancel button
+   *
+   * @return Type: React.ReactNode - JSX button
+   */
   getCancelButton(): React.ReactNode {
     return (
       <button
@@ -110,13 +128,12 @@ export class NewThreadCard extends React.Component<
     );
   }
 
-  // TODO: Get correct type
   /**
    * Handles when the comment box changes
    *
-   * @param e Type: any - input box event
+   * @param e Type: React.ChangeEvent<HTMLTextAreaElement> - input box event
    */
-  handleChangeCommentBox(e: any): void {
+  handleChangeCommentBox(e: React.ChangeEvent<HTMLTextAreaElement>): void {
     this.setState({ inputBox: e.target.value });
   }
 
@@ -133,9 +150,9 @@ export class NewThreadCard extends React.Component<
   /**
    * Handles key events
    *
-   * @param e Type: ? - keyboard event
+   * @param e Type: React.KeyboardEvent - keyboard event
    */
-  handleKeyPress(e: any): void {
+  handleKeyPress(e: React.KeyboardEvent): void {
     if (this.state.inputBox.trim() !== '' && e.key === 'Enter' && !e.shiftKey) {
       this.createNewThread();
     }

--- a/src/NewThreadCard.tsx
+++ b/src/NewThreadCard.tsx
@@ -2,6 +2,12 @@ import * as React from 'react';
 
 interface INewThreadCardProps {
   /**
+   * Creator object
+   *
+   * @type any
+   */
+  creator: any;
+  /**
    * Function to put comment back to server
    *
    * @param comment Type: string -  the comment to be added
@@ -18,12 +24,6 @@ interface INewThreadCardProps {
    * @type void function
    */
   setNewThreadActive: (state: boolean) => void;
-  /**
-   * Creator object
-   *
-   * @type any
-   */
-  creator: any;
 }
 
 interface INewThreadCardStates {
@@ -50,8 +50,15 @@ export class NewThreadCard extends React.Component<
 
     this.handleChangeCommentBox = this.handleChangeCommentBox.bind(this);
     this.handleKeyPress = this.handleKeyPress.bind(this);
-    this.createNewThread = this.createNewThread.bind(this);
-    this.cancelThread = this.cancelThread.bind(this);
+    this.handleCreateNewThread = this.handleCreateNewThread.bind(this);
+    this.handleCancelThread = this.handleCancelThread.bind(this);
+  }
+
+  /**
+   * Called when a component is mounted
+   */
+  componentDidMount(): void {
+    document.getElementById('commentBox').focus();
   }
 
   /**
@@ -87,13 +94,6 @@ export class NewThreadCard extends React.Component<
   }
 
   /**
-   * Called when a component is mounted
-   */
-  componentDidMount(): void {
-    document.getElementById('commentBox').focus();
-  }
-
-  /**
    * Creates and returns the comment button
    *
    * @return Type: React.ReactNode - JSX button
@@ -103,27 +103,10 @@ export class NewThreadCard extends React.Component<
       <button
         className="jp-commenting-button-blue"
         type="button"
-        onClick={this.createNewThread}
+        onClick={this.handleCreateNewThread}
         disabled={this.state.inputBox.trim() === ''}
       >
         Comment
-      </button>
-    );
-  }
-
-  /**
-   * Creates and returns the cancel button
-   *
-   * @return Type: React.ReactNode - JSX button
-   */
-  getCancelButton(): React.ReactNode {
-    return (
-      <button
-        className="jp-commenting-button-red"
-        type="button"
-        onClick={this.cancelThread}
-      >
-        Cancel
       </button>
     );
   }
@@ -137,12 +120,12 @@ export class NewThreadCard extends React.Component<
     this.setState({ inputBox: e.target.value });
   }
 
-  createNewThread(): void {
+  handleCreateNewThread(): void {
     this.props.setNewThreadActive(false);
     this.props.putThread(this.state.inputBox);
   }
 
-  cancelThread(): void {
+  handleCancelThread(): void {
     this.setState({ inputBox: '' });
     this.props.setNewThreadActive(false);
   }
@@ -154,8 +137,25 @@ export class NewThreadCard extends React.Component<
    */
   handleKeyPress(e: React.KeyboardEvent): void {
     if (this.state.inputBox.trim() !== '' && e.key === 'Enter' && !e.shiftKey) {
-      this.createNewThread();
+      this.handleCreateNewThread();
     }
+  }
+
+  /**
+   * Creates and returns the cancel button
+   *
+   * @return Type: React.ReactNode - JSX button
+   */
+  getCancelButton(): React.ReactNode {
+    return (
+      <button
+        className="jp-commenting-button-red"
+        type="button"
+        onClick={this.handleCancelThread}
+      >
+        Cancel
+      </button>
+    );
   }
 
   /**

--- a/src/NewThreadCard.tsx
+++ b/src/NewThreadCard.tsx
@@ -54,9 +54,13 @@ export class NewThreadCard extends React.Component<
    */
   render() {
     return (
-      <div className="jp-commenting-new-thread-area">
-        <label style={this.styles.name}>{this.props.creator.name}</label>
-        <div style={this.styles.inputBoxArea}>
+      <div style={this.styles['jp-commenting-new-thread-area']}>
+        <div style={this.styles['jp-commenting-new-thread-name-area']}>
+          <span style={this.styles['jp-commenting-new-thread-name']}>
+            {this.props.creator.name}
+          </span>
+        </div>
+        <div style={this.styles['jp-commenting-text-input-area']}>
           <textarea
             className="jp-commenting-text-area"
             id={'commentBox'}
@@ -69,7 +73,7 @@ export class NewThreadCard extends React.Component<
             onKeyPress={this.handleKeyPress}
           />
         </div>
-        <div style={this.styles.buttons}>
+        <div style={this.styles['jp-commenting-new-thread-button-area']}>
           {this.getCommentButton()}
           {this.getCancelButton()}
         </div>
@@ -141,26 +145,32 @@ export class NewThreadCard extends React.Component<
    * CSS styles
    */
   styles = {
-    inputBoxArea: {
+    'jp-commenting-new-thread-area': {
+      display: 'flex',
+      justifyContent: 'space-between',
+      flexDirection: 'column' as 'column',
+      borderRadius: 'var(--jp-border-radius)',
+      border: '1px solid var(--jp-border-color2)',
+      boxSizing: 'border-box' as 'border-box'
+    },
+    'jp-commenting-text-input-area': {
       display: 'flex',
       padding: '4px',
       maxWidth: '95%',
-      minHeight: '80px',
-      lineHeight: 'normal'
+      minHeight: '80px'
     },
-    name: {
-      display: 'flex',
-      fontSize: '16px',
+    'jp-commenting-new-thread-name': {
+      fontSize: 'var(--jp-ui-font-size1)',
       fontWeight: 'bold' as 'bold',
-      marginTop: '4px',
-      marginBottom: '4px',
-      marginLeft: '4px'
+      color: 'var(--jp-ui-font-color1)'
     },
-    buttons: {
+    'jp-commenting-new-thread-name-area': {
       display: 'flex',
-      marginTop: '12px',
-      marginBottom: '4px',
-      marginLeft: '4px'
+      padding: '4px'
+    },
+    'jp-commenting-new-thread-button-area': {
+      display: 'flex',
+      padding: '4px'
     }
   };
 }

--- a/src/UserSet.tsx
+++ b/src/UserSet.tsx
@@ -42,7 +42,7 @@ export class UserSet extends React.Component<IUserSetProps, IUserSetStates> {
   /**
    * React render function
    */
-  render() {
+  render(): React.ReactNode {
     return (
       <div style={this.styles['jp-commenting-user-set-area']}>
         <div style={this.styles['jp-commenting-user-set-title-area']}>
@@ -74,22 +74,21 @@ export class UserSet extends React.Component<IUserSetProps, IUserSetStates> {
     );
   }
 
-  // TODO: Get correct type
   /**
    * Handles when the comment box changes
    *
-   * @param e Type: any - input box event
+   * @param e Type: React.ChangeEvent<HTMLInputElement> - input box event
    */
-  handleInputChange(e: any): void {
+  handleInputChange(e: React.ChangeEvent<HTMLInputElement>): void {
     this.setState({ inputBox: e.target.value });
   }
 
   /**
    * Handles key events
    *
-   * @param e Type: ? - keyboard event
+   * @param e Type: React.KeyboardEvent - keyboard event
    */
-  handleKeyPress(e: any): void {
+  handleKeyPress(e: React.KeyboardEvent): void {
     if (e.key === 'Enter' && !e.shiftKey) {
       this.handleSubmit();
     }

--- a/src/UserSet.tsx
+++ b/src/UserSet.tsx
@@ -44,17 +44,23 @@ export class UserSet extends React.Component<IUserSetProps, IUserSetStates> {
    */
   render() {
     return (
-      <div className="jp-commenting-user-set-area" style={this.styles.card}>
-        <label style={this.styles.label}>Enter GitHub Username</label>
-        <input
-          type="text"
-          style={this.styles.field}
-          className="bp3-input bp3-small"
-          placeholder="Name"
-          onChange={this.handleInputChange}
-          onKeyPress={this.handleKeyPress}
-        />
-        <div style={{ float: 'right' }}>
+      <div style={this.styles['jp-commenting-user-set-area']}>
+        <div style={this.styles['jp-commenting-user-set-title-area']}>
+          <span style={this.styles['jp-commenting-user-set-title']}>
+            Enter GitHub Username
+          </span>
+        </div>
+        <div style={this.styles['jp-commenting-user-set-input-area']}>
+          <input
+            type="text"
+            style={this.styles['jp-commenting-user-set-input']}
+            className="bp3-input bp3-small"
+            placeholder="Username"
+            onChange={this.handleInputChange}
+            onKeyPress={this.handleKeyPress}
+          />
+        </div>
+        <div style={this.styles['jp-commenting-user-set-button-area']}>
           <button
             className="jp-commenting-button-blue"
             style={{ marginLeft: '0px' }}
@@ -100,23 +106,35 @@ export class UserSet extends React.Component<IUserSetProps, IUserSetStates> {
    * CSS styles
    */
   styles = {
-    card: {
-      paddinTop: '8px',
-      paddingBottom: '4px',
-      paddingLeft: '12px',
-      paddingRight: '12px',
+    'jp-commenting-user-set-area': {
+      display: 'flex',
+      flexDirection: 'column' as 'column',
+      borderRadius: 'var(--jp-border-radius)',
+      borderBottom: '1px solid var(--jp-border-color1)',
+      boxSizing: 'border-box' as 'border-box',
+      boxShadow: '0 1px 1px rgba(0, 0, 0, 0.075)'
+    },
+    'jp-commenting-user-set-title-area': {
+      display: 'flex',
+      padding: '4px'
+    },
+    'jp-commenting-user-set-title': {
       fontSize: 'var(--jp-ui-font-size1)',
-      fontFamily: 'helvetica',
-      border: 'unset'
+      color: 'var(--jp-ui-font-color1)',
+      fontWeight: 'bold' as 'bold'
     },
-    field: {
-      marginBottom: '5px',
-      paddingLeft: '12px',
-      paddingRight: '12px'
+    'jp-commenting-user-set-input-area': {
+      display: 'flex',
+      boxSizing: 'border-box' as 'border-box',
+      padding: '4px'
     },
-    label: {
-      paddingTop: '5px',
-      marginBottom: '5px'
+    'jp-commenting-user-set-input': {
+      boxSizing: 'border-box' as 'border-box',
+      width: '100%'
+    },
+    'jp-commenting-user-set-button-area': {
+      display: 'flex',
+      padding: '4px'
     }
   };
 }

--- a/src/UserSet.tsx
+++ b/src/UserSet.tsx
@@ -54,7 +54,7 @@ export class UserSet extends React.Component<IUserSetProps, IUserSetStates> {
           <input
             type="text"
             style={this.styles['jp-commenting-user-set-input']}
-            className="bp3-input bp3-small"
+            className="jp-commenting-text-area"
             placeholder="Username"
             onChange={this.handleInputChange}
             onKeyPress={this.handleKeyPress}

--- a/src/UserSet.tsx
+++ b/src/UserSet.tsx
@@ -110,7 +110,7 @@ export class UserSet extends React.Component<IUserSetProps, IUserSetStates> {
       display: 'flex',
       flexDirection: 'column' as 'column',
       borderRadius: 'var(--jp-border-radius)',
-      borderBottom: '1px solid var(--jp-border-color1)',
+      borderBottom: '1px solid var(--jp-border-color2)',
       boxSizing: 'border-box' as 'border-box',
       boxShadow: '0 1px 1px rgba(0, 0, 0, 0.075)'
     },

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Type interface for person response from IMetadataPeopleService
+ */
+export interface IPerson {
+  id: string;
+  name: string;
+  image: string;
+}
+
+/**
+ * Type interface for annotations response from IMetadataCommentsService
+ */
+export interface IAnnotationResponse {
+  data: {
+    annotationsByTarget: {
+      [index: number]: {
+        id: string;
+        target: string;
+        context: string;
+        label: string;
+        total: number;
+        resolved: boolean;
+        body: {
+          [index: number]: { value: string; created: string; creator: IPerson };
+        };
+      };
+    };
+  };
+}

--- a/style/index.css
+++ b/style/index.css
@@ -1,5 +1,6 @@
 .jp-commenting-window {
   background: var(--jp-layout-color1);
+  font-family: var(--jp-content-font-family);
   height: 100%;
 }
 
@@ -77,7 +78,7 @@
 .jp-commenting-button-blue {
   background: white;
   color: #2196f3;
-  outline: 0px;
+  outline: 0;
   font-size: var(--jp-content-font-size0);
   font-family: var(--jp-content-font-family);
   line-height: var(--jp-content-line-height);
@@ -89,27 +90,27 @@
 .jp-commenting-button-blue:disabled {
   background: white;
   color: #e0e0e0;
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-blue:disabled:hover {
   background: white;
   color: #e0e0e0;
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-blue:hover {
   background: #e0e0e0;
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-blue:active {
   background: #bdbdbd;
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-blue:focus {
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-resolved {
@@ -129,9 +130,10 @@
   flex-direction: column;
   border-radius: var(--jp-border-radius);
   padding: 1px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--jp-border-color1);
   box-sizing: border-box;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);
+  margin-top: 4px;
 }
 
 .jp-commenting-thread-area:hover {
@@ -143,7 +145,7 @@
   flex-direction: column;
   border-radius: var(--jp-border-radius);
   padding: 1px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--jp-border-color1);
   box-sizing: border-box;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);
 }
@@ -153,7 +155,7 @@
   justify-content: space-between;
   flex-direction: column;
   border-radius: var(--jp-border-radius);
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--jp-border-color1);
   box-sizing: border-box;
 }
 

--- a/style/index.css
+++ b/style/index.css
@@ -147,7 +147,7 @@
 }
 
 .jp-commenting-thread-area:hover {
-  box-shadow: var(--jp-elevation-z6);
+  box-shadow: var(--jp-elevation-z4);
 }
 
 .jp-commenting-thread-area-no-hover {

--- a/style/index.css
+++ b/style/index.css
@@ -7,7 +7,6 @@
 /* Header Options*/
 .jp-commenting-header-options-dropdown-item {
   display: block;
-  width: 100%;
   padding: 0.25rem 1.5rem;
   clear: both;
   font-size: var(--jp-content-font-size1);
@@ -33,11 +32,11 @@
 .jp-commenting-header-options-dropdown-menu {
   position: absolute;
   top: inherit;
+  box-sizing: border-box;
+  z-index: 1;
   right: 0;
-  left: auto;
-  z-index: 1000;
   display: none;
-  float: left;
+  float: right;
   text-align: left;
   list-style: none;
   background-color: var(--jp-ui-inverse-font-color0);

--- a/style/index.css
+++ b/style/index.css
@@ -4,6 +4,7 @@
   height: 100%;
 }
 
+/* Header Options*/
 .jp-commenting-header-options-dropdown-item {
   display: block;
   width: 100%;
@@ -25,7 +26,7 @@
 
 .jp-commenting-header-options-dropdown-item:hover:not(.jp-mod-selected) {
   background: var(--jp-layout-color2);
-  color: var(--jp-ui-font-color0);
+  color: var(--jp-ui-font-color1);
   text-decoration-line: none;
 }
 
@@ -49,6 +50,15 @@
   display: block;
 }
 
+.jp-commenting-header-options-area {
+  display: flex;
+  flex-direction: column;
+  padding: 1px;
+  border-top: 1px solid var(--jp-border-color1);
+  box-sizing: border-box;
+}
+
+/* Buttons */
 .jp-commenting-button-red {
   background: white;
   color: #e57373;
@@ -117,14 +127,7 @@
   background: var(--jp-layout-color2);
 }
 
-.jp-commenting-header-options-area {
-  display: flex;
-  flex-direction: column;
-  padding: 1px;
-  border-top: 1px solid var(--jp-border-color1);
-  box-sizing: border-box;
-}
-
+/* Threads */
 .jp-commenting-thread-area {
   display: flex;
   flex-direction: column;
@@ -150,6 +153,7 @@
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 
+/* New Thread */
 .jp-commenting-new-thread-area {
   display: flex;
   justify-content: space-between;
@@ -164,7 +168,7 @@
   justify-content: space-between;
   flex-direction: row;
   border-radius: var(--jp-border-radius);
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--jp-border-color1);
   box-sizing: border-box;
 }
 
@@ -184,16 +188,7 @@
   margin-left: 5px;
 }
 
-.jp-commenting-user-set-area {
-  display: flex;
-  flex-direction: column;
-  border-radius: var(--jp-border-radius);
-  padding: 1px;
-  border: 1px solid #e0e0e0;
-  box-sizing: border-box;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);
-}
-
+/* Text Area */
 .jp-commenting-text-area {
   border-color: var(--jp-input-border-color);
   border-radius: var(--jp-border-radius);

--- a/style/index.css
+++ b/style/index.css
@@ -53,7 +53,6 @@
 .jp-commenting-header-options-area {
   display: flex;
   flex-direction: column;
-  padding: 1px;
   border-top: 1px solid var(--jp-border-color1);
   box-sizing: border-box;
 }
@@ -154,7 +153,6 @@
   display: flex;
   flex-direction: column;
   border-radius: var(--jp-border-radius);
-  padding: 1px;
   border: 1px solid var(--jp-border-color2);
   box-sizing: border-box;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);

--- a/style/index.css
+++ b/style/index.css
@@ -161,14 +161,6 @@
 }
 
 /* New Thread */
-.jp-commenting-new-thread-area {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
-  border-radius: var(--jp-border-radius);
-  border: 1px solid var(--jp-border-color2);
-  box-sizing: border-box;
-}
 
 .jp-commenting-new-thread-button {
   display: flex;
@@ -191,8 +183,7 @@
   font-size: 13px;
   color: var(--jp-ui-font-color1);
   text-overflow: ellipsis;
-  margin-bottom: 0px;
-  margin-left: 5px;
+  padding-left: 4px;
 }
 
 /* Text Area */
@@ -202,13 +193,16 @@
   border-width: var(--jp-border-width);
   background-color: var(--jp-input-background);
 
-  width: 100%;
   height: 100%;
+  width: 100%;
 
   font-size: var(--jp-content-font-size0);
+  font-family: var(--jp-content-font-family);
+  color: var(--jp-ui-font-color1);
   line-height: normal;
   padding: 4px;
   resize: none;
+  box-sizing: border-box;
 }
 
 .jp-commenting-text-area:hover {

--- a/style/index.css
+++ b/style/index.css
@@ -1,36 +1,6 @@
 .jp-commenting-window {
-  background: var(--jp-layout-color0);
+  background: var(--jp-layout-color1);
   height: 100%;
-}
-
-.jp-commenting-header-options-checkbox-label-enable {
-  display: flex;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: var(--jp-ui-font-size1);
-  text-align: right;
-  margin-bottom: 0px;
-  height: 28px;
-  min-width: 52px;
-  flex-shrink: 1;
-}
-
-.jp-commenting-header-options-checkbox-label-disable {
-  display: flex;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: var(--jp-ui-font-size1);
-  color: #e0e0e0;
-  text-align: right;
-  margin-bottom: 0px;
-  height: 28px;
-}
-
-.jp-commenting-header-options-checkbox {
-  align-self: center;
-  min-width: 18px;
 }
 
 .jp-commenting-header-options-dropdown-item {
@@ -39,10 +9,10 @@
   padding: 0.25rem 1.5rem;
   clear: both;
   font-size: var(--jp-content-font-size1);
-  color: #212529;
+  color: var(--jp-ui-font-color1);
   text-align: inherit;
   white-space: nowrap;
-  background-color: transparent;
+  background: var(--jp-layout-color1);
   border: 0;
 }
 
@@ -150,7 +120,7 @@
   display: flex;
   flex-direction: column;
   padding: 1px;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--jp-border-color1);
   box-sizing: border-box;
 }
 
@@ -206,6 +176,7 @@
   white-space: nowrap;
   overflow: hidden;
   font-size: 13px;
+  color: var(--jp-ui-font-color1);
   text-overflow: ellipsis;
   margin-bottom: 0px;
   margin-left: 5px;

--- a/style/index.css
+++ b/style/index.css
@@ -60,7 +60,7 @@
 
 /* Buttons */
 .jp-commenting-button-red {
-  background: white;
+  background: var(--jp-layout-color1);
   color: #e57373;
   font-size: var(--jp-content-font-size0);
   font-family: var(--jp-content-font-family);
@@ -68,25 +68,25 @@
   border-radius: var(--jp-border-radius);
   box-shadow: none;
   border: none;
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-red:hover {
-  background: #e0e0e0;
-  outline: 0px;
+  background: var(--jp-layout-color2);
+  outline: 0;
 }
 
 .jp-commenting-button-red:active {
-  background: #bdbdbd;
-  outline: 0px;
+  background: var(--jp-layout-color3);
+  outline: 0;
 }
 
 .jp-commenting-button-red:focus {
-  outline: 0px;
+  outline: 0;
 }
 
 .jp-commenting-button-blue {
-  background: white;
+  background: var(--jp-layout-color1);
   color: #2196f3;
   outline: 0;
   font-size: var(--jp-content-font-size0);
@@ -98,24 +98,24 @@
 }
 
 .jp-commenting-button-blue:disabled {
-  background: white;
-  color: #e0e0e0;
+  background: var(--jp-layout-color1);
+  color: var(--jp-layout-color2);
   outline: 0;
 }
 
 .jp-commenting-button-blue:disabled:hover {
-  background: white;
-  color: #e0e0e0;
+  background: var(--jp-layout-color1);
+  color: var(--jp-layout-color2);
   outline: 0;
 }
 
 .jp-commenting-button-blue:hover {
-  background: #e0e0e0;
+  background: var(--jp-layout-color2);
   outline: 0;
 }
 
 .jp-commenting-button-blue:active {
-  background: #bdbdbd;
+  background: var(--jp-layout-color3);
   outline: 0;
 }
 
@@ -127,13 +127,20 @@
   background: var(--jp-layout-color2);
 }
 
+.jp-commenting-button-resolved:hover {
+  background: var(--jp-layout-color3);
+}
+
+.jp-commenting-button-resolved:active {
+  background: var(--md-grey-500);
+}
+
 /* Threads */
 .jp-commenting-thread-area {
   display: flex;
   flex-direction: column;
   border-radius: var(--jp-border-radius);
-  padding: 1px;
-  border: 1px solid var(--jp-border-color1);
+  border: 1px solid var(--jp-border-color2);
   box-sizing: border-box;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);
   margin-top: 4px;
@@ -148,7 +155,7 @@
   flex-direction: column;
   border-radius: var(--jp-border-radius);
   padding: 1px;
-  border: 1px solid var(--jp-border-color1);
+  border: 1px solid var(--jp-border-color2);
   box-sizing: border-box;
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075);
 }
@@ -159,7 +166,7 @@
   justify-content: space-between;
   flex-direction: column;
   border-radius: var(--jp-border-radius);
-  border: 1px solid var(--jp-border-color1);
+  border: 1px solid var(--jp-border-color2);
   box-sizing: border-box;
 }
 
@@ -168,7 +175,7 @@
   justify-content: space-between;
   flex-direction: row;
   border-radius: var(--jp-border-radius);
-  border: 1px solid var(--jp-border-color1);
+  border: 1px solid var(--jp-border-color2);
   box-sizing: border-box;
 }
 

--- a/style/index.css
+++ b/style/index.css
@@ -168,7 +168,7 @@
   box-shadow: var(--jp-elevation-z6);
 }
 
-.jp-commenting-thread-area-disabled {
+.jp-commenting-thread-area-no-hover {
   display: flex;
   flex-direction: column;
   border-radius: var(--jp-border-radius);
@@ -186,7 +186,6 @@
   border: 1px solid #e0e0e0;
   box-sizing: border-box;
 }
-
 
 .jp-commenting-new-thread-button {
   display: flex;
@@ -245,23 +244,4 @@
   background-color: var(--jp-input-active-background);
   border-color: var(--jp-input-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
-}
-
-.jp-commenting-annotation-not-expanded {
-  display: flex;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 350px;
-  max-height: 30px;
-  font-size: var(--jp-content-font-size0);
-  line-height: normal;
-}
-
-.jp-commenting-annotation-expanded {
-  display: flex;
-  font-size: var(--jp-content-font-size0);
-  line-height: normal;
-  max-height: 100%;
-  max-width: 350px;
-  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## In this PR:

### **Styling refactor:**

- All style names are standardized to jp-commenting-<what style applies to>
- Styles use JLab styling variables as much as possible
	- Dark mode support / theme support
- CSS styles that do not need CSS events like :hover, :active, :focused are now
  in the style object at the bottom of the component it applies to
- All sizes are multiples of 4
- Margins removed, padding only
- box-sizing set to border-box on as many elements as possible
- All elements are sized by a parent div/flexbox
	- Children elements fill entire parent area

### **Organization:**

- React prop and state interfaces in alphabetical order
- Fixed function naming standards; get, set, handle .etc
- All components follow the same organization:

	* Imports
	* Interfaces
	* Global variables
	* Class definition
		* Initialize states
		* Bind functions
	* React life cycle functions
	* React render function
	* Miscellaneous functions
	* Handler functions
	* Get functions
	* Set functions
	* CSS style object
- General improvements and fixes