### PR TITLE
Add demo gif to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Stability Experimental](https://img.shields.io/badge/stability-experimental-red.svg)](https://img.shields.io/badge/stability-experimental-red.svg)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-commenting.git/master)
 
+![Annotating notebook cells](https://raw.githubusercontent.com/jupyterlab/jupyterlab-commenting/master/gifs/usage-11.gif)
+
 ## Project Vision
 
 We have articulated our vision for this project as a ["Press Release from the Future"](./press_release.md). We are now pursing that vision to make it a _reality_. Have feedback or want to get involved? [Post an issue!](https://github.com/jupyterlab/jupyterlab-commenting/issues/new)


### PR DESCRIPTION
This looks like awesome work! Thanks to everyone involved.

As a person casually browsing jupyterlab extensions on GitHub I came across this repo and had no idea what it did. I felt like I had to do a reasonable amount of reading and clicking links before figuring it out. Given that you have some awesome gifs in the usage section I think it would be awesome to have one up front to quickly show people what the extension does.