### PR TITLE
Sql storage

### DIFF
--- a/backend/jupyterlab_commenting_service_server/main.py
+++ b/backend/jupyterlab_commenting_service_server/main.py
@@ -8,7 +8,7 @@ path = os.path.dirname(os.path.abspath(__file__))
 database = os.path.join(path, 'comments.db')
 
 try:
-    open(database)
+    open(database, "w+")
 except FileNotFoundError as f:
     print('The file %s could not be found or opened' % (f.filename))
 

--- a/backend/jupyterlab_commenting_service_server/main.py
+++ b/backend/jupyterlab_commenting_service_server/main.py
@@ -23,15 +23,10 @@ async def root():
 @app.get("/getAllComments/")
 async def getAllComments():
     tables = db.table_names()
-
-    all_comments = []
+    all_comments = {}
 
     for target in tables:
-        temp = {}
-
-        temp[target] = db[target].rows
-
-        all_comments.append(temp)
+        all_comments[target] = db[target].rows
 
     return {"comments": all_comments}
 

--- a/backend/jupyterlab_commenting_service_server/main.py
+++ b/backend/jupyterlab_commenting_service_server/main.py
@@ -3,7 +3,7 @@ import json
 import sqlite_utils
 from fastapi import FastAPI
 
-app = FastAPI()
+app = FastAPI(openapi_prefix="/commenting-service")
 path = os.path.dirname(os.path.abspath(__file__))
 database = os.path.join(path, 'comments.db')
 db = sqlite_utils.Database(database)

--- a/backend/jupyterlab_commenting_service_server/main.py
+++ b/backend/jupyterlab_commenting_service_server/main.py
@@ -6,12 +6,6 @@ from fastapi import FastAPI
 app = FastAPI()
 path = os.path.dirname(os.path.abspath(__file__))
 database = os.path.join(path, 'comments.db')
-
-try:
-    open(database, "w+")
-except FileNotFoundError as f:
-    print('The file %s could not be found or opened' % (f.filename))
-
 db = sqlite_utils.Database(database)
 
 

--- a/backend/jupyterlab_commenting_service_server/main.py
+++ b/backend/jupyterlab_commenting_service_server/main.py
@@ -1,0 +1,101 @@
+import os
+import json
+import sqlite_utils
+from fastapi import FastAPI
+
+app = FastAPI()
+path = os.path.dirname(os.path.abspath(__file__))
+database = os.path.join(path, 'comments.db')
+
+try:
+    open(database)
+except FileNotFoundError as f:
+    print('The file %s could not be found or opened' % (f.filename))
+
+db = sqlite_utils.Database(database)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Fastapi"}
+
+
+@app.get("/file/")
+async def getByTarget(target: str):
+    tables = db.table_names()
+
+    if (target in tables):
+        print('Found existing: ' + target)
+        return {"data": db[target].rows}
+    else:
+        print('Creating new table: ' + target)
+
+        db[target].create({
+            "id": int,
+            "total": int,
+            "resolved": bool,
+            "indicator": str,
+            "body": str
+        }, pk=("id"))
+
+        return {"table": target}
+
+
+@app.get("/newThread/")
+async def createNewThread(target: str, value: str, created: str, creator: str,  indicator: dict = None):
+    table = db[target]
+
+    id = 0
+
+    for row in table.rows:
+        id += 1
+
+    body = [
+        {
+            "id": 0,
+            "created": created,
+            "creator": creator,
+            "edited": False,
+            "value": value
+        }
+    ]
+
+    # Convert dict to str and change seperators to use no whitespaces
+    body_trimmed = json.dumps(body, separators=(',', ':'))
+
+    table.insert({
+        "id": id,
+        "total": 1,
+        "resolved": False,
+        "indicator": indicator,
+        "body": body_trimmed
+    })
+
+    return {"created": table.rows}
+
+
+@app.get("/newComment/")
+async def createNewComment(target: str, thread_id: int, value: str, created: str, creator: str):
+    table = db[target]
+
+    thread = table.get(thread_id)
+
+    body = json.loads(thread['body'])
+
+    total_comments = len(body)
+
+    new_comment = {
+        "id": total_comments,
+        "created": created,
+        "creator": creator,
+        "edited": False,
+        "value": value
+    }
+
+    body.append(new_comment)
+
+    new_body = json.dumps(body, separators=(',', ':'))
+
+    table.update(thread_id, {"body": new_body})
+
+    return {"Message": thread}

--- a/backend/jupyterlab_commenting_service_server/service.py
+++ b/backend/jupyterlab_commenting_service_server/service.py
@@ -10,6 +10,12 @@ def start():
         dict -- A dictionary with the command to start the Commenting Service Server
     """
     path = os.path.dirname(os.path.abspath(__file__))
+    database = os.path.join(path, 'comments.db')
+
+    try:
+        open(database, "w+")
+    except FileNotFoundError as f:
+        print('The file %s could not be found or opened' % (f.filename))
 
     return {
         'command': [

--- a/backend/jupyterlab_commenting_service_server/service.py
+++ b/backend/jupyterlab_commenting_service_server/service.py
@@ -1,0 +1,36 @@
+"""Jupyterlab Commenting Service Server"""
+import os
+
+
+def start():
+    """
+    Start Jupyterlab Commenting Service Server Start
+
+    Returns:
+        dict -- A dictionary with the command to start the Commenting Service Server
+    """
+    path = os.path.dirname(os.path.abspath(__file__))
+
+    return {
+        'command': [
+            'datasette', 'serve', os.path.join(
+                path, 'comments.db'), '-p', '{port}', '--cors'
+        ],
+        'timeout': 60,
+        'port': 40000
+    }
+
+
+def fastapi():
+    path = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(path)
+
+    return {
+        'command': [
+            'uvicorn', 'main:app', '--host', '0.0.0.0',
+            '--port', '{port}', '--proxy-headers', '--reload'
+        ],
+        'timeout': 60,
+        'port': 30000,
+        'absolute_url': False
+    }

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,0 +1,42 @@
+import setuptools
+
+from glob import glob
+import os
+
+
+def get_path_files(path):
+    all_files = []
+    path_files = []
+    for f_path in glob(os.path.join(path, '*')):
+        if os.path.isdir(f_path):
+            all_files += get_path_files(f_path)
+        elif f_path[-3:] != '.py':
+            path_files.append(f_path)
+
+    all_files += [(path, path_files)]
+    return all_files
+
+
+path = os.path.join('jupyterlab_commenting_service_server')
+extra_files = get_path_files(path)
+
+setuptools.setup(
+    name="jupyterlab-commenting-service-server",
+    version='0.1',
+    license='BSD-3-Clause',
+    author='CalPoly/Quansight',
+    author_email='jupyterlab@localhost',
+    url='https://github.com/jupyterlab/jupyterlab-commenting',
+    # py_modules rather than packages, since we only have 1 file
+    packages=['jupyterlab_commenting_service_server'],
+    entry_points={
+        'jupyter_serverproxy_servers': [
+            # name = packagename:function_name
+            'comments = jupyterlab_commenting_service_server.service:start',
+            'commenting-service = jupyterlab_commenting_service_server.service:fastapi'
+        ]
+    },
+    install_requires=['jupyter-server-proxy', 'fastapi[all]'],
+    package_data=dict(extra_files),
+    include_package_data=True
+)

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
             'commenting-service = jupyterlab_commenting_service_server.service:fastapi'
         ]
     },
-    install_requires=['jupyter-server-proxy', 'fastapi[all]'],
+    install_requires=['jupyter-server-proxy', 'fastapi[all]', 'datasette'],
     package_data=dict(extra_files),
     include_package_data=True
 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jupyterlab/commenting-extension",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Commenting and annotation for JupyterLab",
     "keywords": [
         "jupyter",

--- a/src/comments/indicator.ts
+++ b/src/comments/indicator.ts
@@ -46,6 +46,13 @@ export class CommentingIndicatorHandler {
     if (curWidget) {
       const context = this._docManager.contextForWidget(curWidget);
 
+      // Connect to save signal of widget to save comments on file save
+      context.saveState.connect((sender, args) => {
+        if (args === 'started') {
+          this._receiver.saveComments(path);
+        }
+      }, this);
+
       if (context) {
         const promise = context.ready;
         promise

--- a/src/comments/indicator.ts
+++ b/src/comments/indicator.ts
@@ -138,9 +138,11 @@ export class CommentingIndicatorHandler {
    * Handles when the target changes
    */
   handleTargetChanged() {
+    const target = this._provider.getState('target') as string;
     // Clear past widget
     this.clearIndicatorWidget();
     this.setIndicatorWidget();
+    this._receiver.saveComments(target);
   }
 
   /**

--- a/src/comments/indicator.ts
+++ b/src/comments/indicator.ts
@@ -28,6 +28,17 @@ export class CommentingIndicatorHandler {
 
     // Called when state 'target' is changed
     this._receiver.targetSet.connect(this.handleTargetChanged, this);
+
+    // Save comments before refresh
+    window.addEventListener('beforeunload', evt => {
+      let path = this._provider.getState('target') as string;
+
+      this._receiver.saveComments(path);
+
+      evt.returnValue = '';
+
+      return null;
+    });
   }
 
   /**
@@ -39,6 +50,8 @@ export class CommentingIndicatorHandler {
     if (!path) {
       return;
     }
+
+    this._receiver.saveComments(path);
 
     const curWidget = this._docManager.findWidget(path);
 

--- a/src/comments/notebook.ts
+++ b/src/comments/notebook.ts
@@ -1,23 +1,23 @@
-import { JupyterFrontEnd, ILabShell } from "@jupyterlab/application";
+import { JupyterFrontEnd, ILabShell } from '@jupyterlab/application';
 
-import { IDocumentManager } from "@jupyterlab/docmanager";
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
-import { NotebookPanel, Notebook } from "@jupyterlab/notebook";
+import { NotebookPanel, Notebook } from '@jupyterlab/notebook';
 
-import { DocumentRegistry, IDocumentWidget } from "@jupyterlab/docregistry";
+import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 
-import { ICellModel, Cell } from "@jupyterlab/cells";
+import { ICellModel, Cell } from '@jupyterlab/cells';
 
-import { Message } from "@phosphor/messaging";
+import { Message } from '@phosphor/messaging';
 
-import { Widget } from "@phosphor/widgets";
+import { Widget } from '@phosphor/widgets';
 
-import { commentingUI, indicatorHandler } from "..";
-import { IndicatorWidget } from "./indicator";
-import { CommentingDataProvider } from "./provider";
-import { CommentingDataReceiver } from "./receiver";
-import { CommentingWidget } from "./commenting";
-import { ICommentThread } from "./service";
+import { commentingUI, indicatorHandler } from '..';
+import { IndicatorWidget } from './indicator';
+import { CommentingDataProvider } from './provider';
+import { CommentingDataReceiver } from './receiver';
+import { CommentingWidget } from './commenting';
+import { ICommentThread } from './service';
 
 export class NotebookIndicators extends Widget implements IndicatorWidget {
   constructor(
@@ -113,7 +113,7 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
    * @param threadId Type: string - threadID of thread to expand
    */
   focusThread(threadId: string): void {
-    if (this._provider.getState("expandedCard") !== threadId) {
+    if (this._provider.getState('expandedCard') !== threadId) {
       commentingUI.setExpandedCard(threadId);
       this.putIndicators();
     }
@@ -156,11 +156,11 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
 
     let metadata = cell.metadata;
 
-    if (!metadata.has("comments")) {
+    if (!metadata.has('comments')) {
       return 0;
     }
 
-    let threads = cell.metadata.get("comments");
+    let threads = cell.metadata.get('comments');
 
     return threads.length;
   }
@@ -179,30 +179,30 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
     let cellNodes = panel.layout.parent.node.childNodes;
 
     cellNodes.forEach((child: ChildNode, index: number) => {
-      let button = document.createElement("div");
+      let button = document.createElement('div');
 
       button.className =
         panel.activeCellIndex === index
-          ? this._provider.getState("newThreadActive")
+          ? this._provider.getState('newThreadActive')
             ? this._cellIndexClicked
-              ? "jp-Icon jp-ChatIconBlue"
-              : "jp-Icon jp-NbCommentIcon"
-            : "jp-Icon jp-NbCommentIcon"
-          : "";
+              ? 'jp-Icon jp-ChatIconBlue'
+              : 'jp-Icon jp-NbCommentIcon'
+            : 'jp-Icon jp-NbCommentIcon'
+          : '';
 
       button.hidden = panel.activeCellIndex !== index;
 
-      button.style.minWidth = "20px";
-      button.style.minHeight = "20px";
-      button.style.backgroundSize = "20px";
-      button.style.padding = "4px";
-      button.style.cssFloat = "right";
-      button.style.cursor = this._provider.getState("newThreadActive")
-        ? ""
-        : "pointer";
+      button.style.minWidth = '20px';
+      button.style.minHeight = '20px';
+      button.style.backgroundSize = '20px';
+      button.style.padding = '4px';
+      button.style.cssFloat = 'right';
+      button.style.cursor = this._provider.getState('newThreadActive')
+        ? ''
+        : 'pointer';
 
       button.id =
-        "nb-commenting-create-button-" + this._uniqueId() + "/" + index;
+        'nb-commenting-create-button-' + this._uniqueId() + '/' + index;
 
       // Cell element node
       let insertPosition =
@@ -210,8 +210,8 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
 
       insertPosition.before(button);
 
-      button.addEventListener("click", () => {
-        if (this._provider.getState("newThreadActive")) {
+      button.addEventListener('click', () => {
+        if (this._provider.getState('newThreadActive')) {
           return;
         }
 
@@ -219,13 +219,13 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
 
         let panel = this._panelWidget.content as any; // Should be NotebookPanel
 
-        let id = button.id.split("/").pop();
+        let id = button.id.split('/').pop();
         this._cellIndexClicked = Number(id);
 
         panel.activeCellIndex = this._cellIndexClicked;
 
-        button.className = "jp-Icon jp-ChatIconBlue";
-        button.style.cursor = "";
+        button.className = 'jp-Icon jp-ChatIconBlue';
+        button.style.cursor = '';
       });
 
       this._createThreadButtons.push(button);
@@ -239,15 +239,15 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
       let id = this._getCellIndexFromId(element.id);
 
       if (
-        !this._provider.getState("newThreadActive") &&
+        !this._provider.getState('newThreadActive') &&
         panel.activeCellIndex === id
       ) {
         element.hidden = false;
-        element.className = "jp-Icon jp-NbCommentIcon";
+        element.className = 'jp-Icon jp-NbCommentIcon';
       }
 
       if (panel.activeCellIndex !== id) {
-        element.className = "";
+        element.className = '';
         element.hidden = true;
       }
     });
@@ -286,18 +286,18 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
 
     let cell: ChildNode = cellNodes[index];
 
-    let indicator = document.createElement("div");
+    let indicator = document.createElement('div');
 
-    indicator.className = "jp-Icon jp-ChatIcon";
-    indicator.style.minWidth = "20px";
-    indicator.style.minHeight = "20px";
-    indicator.style.backgroundSize = "20px";
-    indicator.style.padding = "10px";
-    indicator.style.cssFloat = "right";
-    indicator.style.textAlign = "center";
-    indicator.style.fontWeight = "bold";
+    indicator.className = 'jp-Icon jp-ChatIcon';
+    indicator.style.minWidth = '20px';
+    indicator.style.minHeight = '20px';
+    indicator.style.backgroundSize = '20px';
+    indicator.style.padding = '10px';
+    indicator.style.cssFloat = 'right';
+    indicator.style.textAlign = 'center';
+    indicator.style.fontWeight = 'bold';
 
-    indicator.id = "nb-commenting-indicator-" + this._uniqueId() + "/" + index;
+    indicator.id = 'nb-commenting-indicator-' + this._uniqueId() + '/' + index;
 
     cell.childNodes[1].childNodes[1].firstChild.appendChild(indicator);
 
@@ -337,12 +337,12 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
 
       let nextCommentId = this._receiver
         .getLatestCommentId()
-        .split("/")
+        .split('/')
         .pop();
 
-      let latestCommentId = "anno/" + (Number(nextCommentId) - 1);
+      let latestCommentId = 'anno/' + (Number(nextCommentId) - 1);
 
-      let threads = this._provider.getState("response") as Array<
+      let threads = this._provider.getState('response') as Array<
         ICommentThread
       >;
 
@@ -356,14 +356,14 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
 
       let metadata = cell.metadata;
 
-      if (metadata.has("comments")) {
-        let curThreads = metadata.get("comments") as Array<{}>;
+      if (metadata.has('comments')) {
+        let curThreads = metadata.get('comments') as Array<{}>;
 
         curThreads.push(thread);
 
-        cell.metadata.set("comments", curThreads);
+        cell.metadata.set('comments', curThreads);
       } else {
-        cell.metadata.set("comments", [thread]);
+        cell.metadata.set('comments', [thread]);
       }
 
       this.putIndicators();
@@ -383,7 +383,7 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
     let cells = panel.model.cells;
 
     for (let i = 0; i < cells.length; i++) {
-      cells.get(i).metadata.delete("comments");
+      cells.get(i).metadata.delete('comments');
     }
   }
 
@@ -399,7 +399,7 @@ export class NotebookIndicators extends Widget implements IndicatorWidget {
   }
 
   private _getCellIndexFromId(id: string): number {
-    return Number(id.split("/").pop());
+    return Number(id.split('/').pop());
   }
 
   private _app: JupyterFrontEnd;

--- a/src/comments/receiver.ts
+++ b/src/comments/receiver.ts
@@ -1,11 +1,11 @@
-import { IFileBrowserFactory } from "@jupyterlab/filebrowser";
+import { ISignal, Signal } from '@phosphor/signaling';
 
-import { ISignal, Signal } from "@phosphor/signaling";
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
-import { CommentingStates, ICommentStates } from "./states";
-import { IPerson, CommentIndicator } from "./service";
-import { CommentsService } from "./service";
-import { ICommentingServiceConnection } from "./service_connection";
+import { CommentingStates, ICommentStates } from './states';
+import { IPerson, CommentIndicator } from './service';
+import { CommentsService } from './service';
+import { ICommentingServiceConnection } from './service_connection';
 
 /**
  * Handles all interactions with data that is received. Interacts with CommentingStates
@@ -14,31 +14,31 @@ import { ICommentingServiceConnection } from "./service_connection";
 export class CommentingDataReceiver {
   constructor(
     states: CommentingStates,
-    browserFactory: IFileBrowserFactory,
-    service: ICommentingServiceConnection
+    service: ICommentingServiceConnection,
+    docManager: IDocumentManager
   ) {
     this._states = states;
 
     // Create CommentsService object
-    this._commentService = new CommentsService(browserFactory, service);
+    this._commentService = new CommentsService(service);
 
     // Initial states
     this.setState({
       creator: {},
       curTargetHasThreads: false,
-      expandedCard: " ",
+      expandedCard: ' ',
       myThreads: [],
       newThreadActive: false,
-      newThreadFile: " ",
-      replyActiveCard: " ",
+      newThreadFile: ' ',
+      replyActiveCard: ' ',
       response: {},
-      pastTarget: "",
+      pastTarget: '',
       showResolved: true,
-      sortState: "latest",
+      sortState: 'latest',
       userSet: false,
-      target: " ",
+      target: ' ',
       widgetMatchTarget: false,
-      isEditing: "",
+      isEditing: '',
       threadIdList: []
     });
 
@@ -66,9 +66,9 @@ export class CommentingDataReceiver {
    * Handles getting all comments from comments service that relate to the current target
    */
   getAllComments(): void {
-    let target = this._states.getState("target") as string;
-    let sortBy = this._states.getState("sortState") as string;
-    let idList = this._states.getState("threadIdList") as Array<string>;
+    let target = this._states.getState('target') as string;
+    let sortBy = this._states.getState('sortState') as string;
+    let idList = this._states.getState('threadIdList') as Array<string>;
 
     if (!target) {
       this._states.setState({ response: {}, curTargetHasThreads: false });
@@ -105,7 +105,7 @@ export class CommentingDataReceiver {
       target,
       threadId,
       value,
-      (this._states.getState("creator") as Object) as IPerson
+      (this._states.getState('creator') as Object) as IPerson
     );
 
     this._newDataReceived.emit(void 0);
@@ -138,7 +138,7 @@ export class CommentingDataReceiver {
    */
   putThreadEdit(threadId: string, value: string): void {
     this._commentService.editThread(
-      this._states.getState("target") as string,
+      this._states.getState('target') as string,
       threadId,
       value
     );
@@ -153,9 +153,9 @@ export class CommentingDataReceiver {
    */
   putThread(value: string): void {
     this._commentService.createThread(
-      this._states.getState("target") as string,
+      this._states.getState('target') as string,
       value,
-      (this._states.getState("creator") as Object) as IPerson
+      (this._states.getState('creator') as Object) as IPerson
     );
     this._newDataReceived.emit(void 0);
 
@@ -199,7 +199,7 @@ export class CommentingDataReceiver {
    * key: threadId, value CommentIndicator
    */
   getAllIndicatorValues(): { [key: string]: CommentIndicator } {
-    let target = this._states.getState("target") as string;
+    let target = this._states.getState('target') as string;
     return this._commentService.getAllIndicatorValues(target);
   }
 
@@ -218,7 +218,7 @@ export class CommentingDataReceiver {
    */
   deleteComment(threadId: string, index: number): void {
     this._commentService.deleteComment(
-      this._states.getState("target") as string,
+      this._states.getState('target') as string,
       threadId,
       index
     );
@@ -231,15 +231,24 @@ export class CommentingDataReceiver {
    * @param value Type: string - target to update to
    */
   setTarget(value: string) {
-    if (value === this._states.getState("target")) {
+    if (value === this._states.getState('target')) {
       return;
     }
     this._states.setState({
       target: value,
       newThreadActive: false,
-      expandedCard: " "
+      expandedCard: ' '
     });
     this._targetSet.emit(void 0);
+  }
+
+  /**
+   * Saves comments
+   *
+   * @param target Type: string - target to save comments for
+   */
+  saveComments(target: string): void {
+    this._commentService.saveComments(target);
   }
 
   /**
@@ -248,13 +257,13 @@ export class CommentingDataReceiver {
    * @param user Type: string - users github username
    */
   async setUserInfo(user: string) {
-    const response = await fetch("https://api.github.com/users/" + user);
+    const response = await fetch('https://api.github.com/users/' + user);
     const myJSON = await response.json();
 
     // If users does not have a name set, use username
     const name = myJSON.name === null ? myJSON.login : myJSON.name;
-    if (myJSON.message !== "Not Found") {
-      if (!this._states.getState("userSet")) {
+    if (myJSON.message !== 'Not Found') {
+      if (!this._states.getState('userSet')) {
         this._states.setState({
           creator: {
             name: name,
@@ -265,7 +274,7 @@ export class CommentingDataReceiver {
         });
       }
     } else {
-      window.alert("Username not found");
+      window.alert('Username not found');
     }
   }
 

--- a/src/comments/receiver.ts
+++ b/src/comments/receiver.ts
@@ -1,39 +1,44 @@
-import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { IFileBrowserFactory } from "@jupyterlab/filebrowser";
 
-import { ISignal, Signal } from '@phosphor/signaling';
+import { ISignal, Signal } from "@phosphor/signaling";
 
-import { CommentingStates, ICommentStates } from './states';
-import { IPerson, CommentIndicator } from './service';
-import { CommentsService } from './service';
+import { CommentingStates, ICommentStates } from "./states";
+import { IPerson, CommentIndicator } from "./service";
+import { CommentsService } from "./service";
+import { ICommentingServiceConnection } from "./service_connection";
 
 /**
  * Handles all interactions with data that is received. Interacts with CommentingStates
  * and sets values accordingly.
  */
 export class CommentingDataReceiver {
-  constructor(states: CommentingStates, browserFactory: IFileBrowserFactory) {
+  constructor(
+    states: CommentingStates,
+    browserFactory: IFileBrowserFactory,
+    service: ICommentingServiceConnection
+  ) {
     this._states = states;
 
     // Create CommentsService object
-    this._commentService = new CommentsService(browserFactory);
+    this._commentService = new CommentsService(browserFactory, service);
 
     // Initial states
     this.setState({
       creator: {},
       curTargetHasThreads: false,
-      expandedCard: ' ',
+      expandedCard: " ",
       myThreads: [],
       newThreadActive: false,
-      newThreadFile: ' ',
-      replyActiveCard: ' ',
+      newThreadFile: " ",
+      replyActiveCard: " ",
       response: {},
-      pastTarget: '',
+      pastTarget: "",
       showResolved: true,
-      sortState: 'latest',
+      sortState: "latest",
       userSet: false,
-      target: ' ',
+      target: " ",
       widgetMatchTarget: false,
-      isEditing: '',
+      isEditing: "",
       threadIdList: []
     });
 
@@ -61,9 +66,9 @@ export class CommentingDataReceiver {
    * Handles getting all comments from comments service that relate to the current target
    */
   getAllComments(): void {
-    let target = this._states.getState('target') as string;
-    let sortBy = this._states.getState('sortState') as string;
-    let idList = this._states.getState('threadIdList') as Array<string>;
+    let target = this._states.getState("target") as string;
+    let sortBy = this._states.getState("sortState") as string;
+    let idList = this._states.getState("threadIdList") as Array<string>;
 
     if (!target) {
       this._states.setState({ response: {}, curTargetHasThreads: false });
@@ -100,7 +105,7 @@ export class CommentingDataReceiver {
       target,
       threadId,
       value,
-      (this._states.getState('creator') as Object) as IPerson
+      (this._states.getState("creator") as Object) as IPerson
     );
 
     this._newDataReceived.emit(void 0);
@@ -133,7 +138,7 @@ export class CommentingDataReceiver {
    */
   putThreadEdit(threadId: string, value: string): void {
     this._commentService.editThread(
-      this._states.getState('target') as string,
+      this._states.getState("target") as string,
       threadId,
       value
     );
@@ -148,9 +153,9 @@ export class CommentingDataReceiver {
    */
   putThread(value: string): void {
     this._commentService.createThread(
-      this._states.getState('target') as string,
+      this._states.getState("target") as string,
       value,
-      (this._states.getState('creator') as Object) as IPerson
+      (this._states.getState("creator") as Object) as IPerson
     );
     this._newDataReceived.emit(void 0);
 
@@ -194,7 +199,7 @@ export class CommentingDataReceiver {
    * key: threadId, value CommentIndicator
    */
   getAllIndicatorValues(): { [key: string]: CommentIndicator } {
-    let target = this._states.getState('target') as string;
+    let target = this._states.getState("target") as string;
     return this._commentService.getAllIndicatorValues(target);
   }
 
@@ -213,7 +218,7 @@ export class CommentingDataReceiver {
    */
   deleteComment(threadId: string, index: number): void {
     this._commentService.deleteComment(
-      this._states.getState('target') as string,
+      this._states.getState("target") as string,
       threadId,
       index
     );
@@ -226,13 +231,13 @@ export class CommentingDataReceiver {
    * @param value Type: string - target to update to
    */
   setTarget(value: string) {
-    if (value === this._states.getState('target')) {
+    if (value === this._states.getState("target")) {
       return;
     }
     this._states.setState({
       target: value,
       newThreadActive: false,
-      expandedCard: ' '
+      expandedCard: " "
     });
     this._targetSet.emit(void 0);
   }
@@ -243,13 +248,13 @@ export class CommentingDataReceiver {
    * @param user Type: string - users github username
    */
   async setUserInfo(user: string) {
-    const response = await fetch('https://api.github.com/users/' + user);
+    const response = await fetch("https://api.github.com/users/" + user);
     const myJSON = await response.json();
 
     // If users does not have a name set, use username
     const name = myJSON.name === null ? myJSON.login : myJSON.name;
-    if (myJSON.message !== 'Not Found') {
-      if (!this._states.getState('userSet')) {
+    if (myJSON.message !== "Not Found") {
+      if (!this._states.getState("userSet")) {
         this._states.setState({
           creator: {
             name: name,
@@ -260,7 +265,7 @@ export class CommentingDataReceiver {
         });
       }
     } else {
-      window.alert('Username not found');
+      window.alert("Username not found");
     }
   }
 

--- a/src/comments/service.ts
+++ b/src/comments/service.ts
@@ -377,7 +377,13 @@ export class CommentsService {
       .then(comments => {
         Object.keys(comments['comments']).forEach(target => {
           comments.comments[target].forEach(thread => {
+            // Parse body json string into json object
             thread['body'] = JSON.parse(thread['body']);
+
+            // If there is an indicator parse json string into json object
+            if (thread['indicator']) {
+              thread['indicator'] = JSON.parse(thread['indicator']);
+            }
           });
         });
         this._commentsStore = comments.comments;
@@ -386,7 +392,7 @@ export class CommentsService {
           this._nextCommentId += this._commentsStore[key].length;
         });
       })
-      .catch();
+      .catch(e => console.error('error loading comments', e));
   }
 
   /**

--- a/src/comments/service.ts
+++ b/src/comments/service.ts
@@ -379,12 +379,9 @@ export class CommentsService {
       .query('getAllComments/')
       .then(response => response.json())
       .then(comments => {
-        comments['comments'].forEach(threads => {
-          console.log('threads', threads);
-          Object.keys(threads).forEach(target => {
-            threads[target].forEach(thread => {
-              thread['body'] = JSON.parse(thread['body']);
-            });
+        Object.keys(comments['comments']).forEach(target => {
+          comments.comments[target].forEach(thread => {
+            thread['body'] = JSON.parse(thread['body']);
           });
         });
         console.log(comments);

--- a/src/comments/service.ts
+++ b/src/comments/service.ts
@@ -354,8 +354,6 @@ export class CommentsService {
   }
 
   saveComments(target: string): void {
-    console.log('SAVED', target);
-
     if (!this._commentsStore[target]) {
       return;
     }
@@ -364,15 +362,13 @@ export class CommentsService {
 
     this._service
       .query('saveComments/?comments=' + comments + '&target=' + target)
-      .then(r => console.log(r.json()));
+      .catch();
   }
 
   /**
    * Loads the contents of comments.json into memory
    */
   loadComments(): void {
-    // this._service.query('file/?target=' + target).then(response => {
-    //   console.log('Response', response);
     console.log('Loading comments...');
 
     this._service
@@ -384,14 +380,11 @@ export class CommentsService {
             thread['body'] = JSON.parse(thread['body']);
           });
         });
-        console.log(comments);
         this._commentsStore = comments.comments;
 
         Object.keys(this._commentsStore).forEach(key => {
           this._nextCommentId += this._commentsStore[key].length;
         });
-
-        console.log('commentsStore', this._commentsStore);
       })
       .catch();
   }

--- a/src/comments/service_connection.ts
+++ b/src/comments/service_connection.ts
@@ -1,0 +1,43 @@
+import { Token } from "@phosphor/coreutils";
+
+import { PageConfig } from "@jupyterlab/coreutils";
+
+import { JupyterFrontEnd } from "@jupyterlab/application";
+
+export const ICommentingServiceConnection = new Token<
+  ICommentingServiceConnection
+>("@jupyterlab/commenting-service:ICommentingServiceConnection");
+
+export interface ICommentingServiceConnection {
+  query(database: string): Promise<Response>;
+}
+
+class CommentingServiceConnection implements ICommentingServiceConnection {
+  serviceUrl: string;
+
+  constructor() {
+    console.log("Starting commenting service", PageConfig);
+
+    let baseUrl = PageConfig.getBaseUrl();
+
+    this.serviceUrl = baseUrl + "commenting-service/";
+
+    fetch(this.serviceUrl);
+    fetch(baseUrl + "comments/");
+
+    console.log("Commenting API:", this.serviceUrl);
+    console.log("Commenting Datasette:", baseUrl + "comments");
+  }
+
+  query(request: string): Promise<Response> {
+    let info = fetch(this.serviceUrl + request);
+
+    return info;
+  }
+}
+
+export function activateCommentingServiceConnection(
+  app: JupyterFrontEnd
+): ICommentingServiceConnection {
+  return new CommentingServiceConnection();
+}

--- a/src/comments/service_connection.ts
+++ b/src/comments/service_connection.ts
@@ -1,12 +1,12 @@
-import { Token } from "@phosphor/coreutils";
+import { Token } from '@phosphor/coreutils';
 
-import { PageConfig } from "@jupyterlab/coreutils";
+import { PageConfig } from '@jupyterlab/coreutils';
 
-import { JupyterFrontEnd } from "@jupyterlab/application";
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export const ICommentingServiceConnection = new Token<
   ICommentingServiceConnection
->("@jupyterlab/commenting-service:ICommentingServiceConnection");
+>('@jupyterlab/commenting-service:ICommentingServiceConnection');
 
 export interface ICommentingServiceConnection {
   query(database: string): Promise<Response>;
@@ -16,17 +16,14 @@ class CommentingServiceConnection implements ICommentingServiceConnection {
   serviceUrl: string;
 
   constructor() {
-    console.log("Starting commenting service", PageConfig);
+    console.log('Starting commenting service', PageConfig);
 
     let baseUrl = PageConfig.getBaseUrl();
 
-    this.serviceUrl = baseUrl + "commenting-service/";
+    this.serviceUrl = baseUrl + 'commenting-service/';
 
     fetch(this.serviceUrl);
-    fetch(baseUrl + "comments/");
-
-    console.log("Commenting API:", this.serviceUrl);
-    console.log("Commenting Datasette:", baseUrl + "comments");
+    fetch(baseUrl + 'comments/');
   }
 
   query(request: string): Promise<Response> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,25 @@
-import '../style/index.css';
+import "../style/index.css";
 
 import {
   JupyterFrontEndPlugin,
   ILabShell,
   JupyterFrontEnd
-} from '@jupyterlab/application';
+} from "@jupyterlab/application";
 
-import { IEditorTracker } from '@jupyterlab/fileeditor';
+import { IEditorTracker } from "@jupyterlab/fileeditor";
 
-import { IDocumentManager } from '@jupyterlab/docmanager';
+import { IDocumentManager } from "@jupyterlab/docmanager";
 
-import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { IFileBrowserFactory } from "@jupyterlab/filebrowser";
 
-import { CommentingWidget } from './comments/commenting';
-import { CommentingStates } from './comments/states';
-import { CommentingDataProvider } from './comments/provider';
-import { CommentingDataReceiver } from './comments/receiver';
-import { CommentingIndicatorHandler } from './comments/indicator';
+import { ICommentingServiceConnection } from "./comments/service_connection";
+import { activateCommentingServiceConnection } from "./comments/service_connection";
+
+import { CommentingWidget } from "./comments/commenting";
+import { CommentingStates } from "./comments/states";
+import { CommentingDataProvider } from "./comments/provider";
+import { CommentingDataReceiver } from "./comments/receiver";
+import { CommentingIndicatorHandler } from "./comments/indicator";
 
 /**
  * CommentingUI
@@ -53,19 +56,20 @@ export function activate(
   labShell: ILabShell,
   tracker: IEditorTracker,
   docManager: IDocumentManager,
-  browserFactory: IFileBrowserFactory
+  browserFactory: IFileBrowserFactory,
+  service: ICommentingServiceConnection
 ) {
   // Create receiver object
-  receiver = new CommentingDataReceiver(states, browserFactory);
+  receiver = new CommentingDataReceiver(states, browserFactory, service);
 
   // Create CommentingUI React widget
   commentingUI = new CommentingWidget(provider, receiver);
-  commentingUI.id = 'jupyterlab-commenting:commentsUI';
-  commentingUI.title.iconClass = 'jp-ChatIcon jp-SideBar-tabIcon';
-  commentingUI.title.caption = 'Commenting';
+  commentingUI.id = "jupyterlab-commenting:commentsUI";
+  commentingUI.title.iconClass = "jp-ChatIcon jp-SideBar-tabIcon";
+  commentingUI.title.caption = "Commenting";
 
   // Add widget to the right area
-  labShell.add(commentingUI, 'right');
+  labShell.add(commentingUI, "right");
 
   // Create CommentingIndicatorHandler
   indicatorHandler = new CommentingIndicatorHandler(
@@ -104,12 +108,31 @@ export function activate(
 
 // creates extension
 const commentingExtension: JupyterFrontEndPlugin<void> = {
-  id: 'jupyterlab-commenting:commentsUI',
+  id: "jupyterlab-commenting:commentsUI",
   autoStart: true,
-  requires: [ILabShell, IEditorTracker, IDocumentManager, IFileBrowserFactory],
+  requires: [
+    ILabShell,
+    IEditorTracker,
+    IDocumentManager,
+    IFileBrowserFactory,
+    ICommentingServiceConnection
+  ],
   activate
 };
 
-const plugins: JupyterFrontEndPlugin<any>[] = [commentingExtension];
+const commentServiceExtension: JupyterFrontEndPlugin<
+  ICommentingServiceConnection
+> = {
+  id: "jupyterlab-commenting-service-server",
+  autoStart: true,
+  requires: [],
+  provides: ICommentingServiceConnection,
+  activate: activateCommentingServiceConnection
+};
+
+const plugins: JupyterFrontEndPlugin<any>[] = [
+  commentingExtension,
+  commentServiceExtension
+];
 
 export default plugins;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,25 @@
-import "../style/index.css";
+import '../style/index.css';
 
 import {
   JupyterFrontEndPlugin,
   ILabShell,
   JupyterFrontEnd
-} from "@jupyterlab/application";
+} from '@jupyterlab/application';
 
-import { IEditorTracker } from "@jupyterlab/fileeditor";
+import { IEditorTracker } from '@jupyterlab/fileeditor';
 
-import { IDocumentManager } from "@jupyterlab/docmanager";
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
-import { IFileBrowserFactory } from "@jupyterlab/filebrowser";
+import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
-import { ICommentingServiceConnection } from "./comments/service_connection";
-import { activateCommentingServiceConnection } from "./comments/service_connection";
+import { ICommentingServiceConnection } from './comments/service_connection';
+import { activateCommentingServiceConnection } from './comments/service_connection';
 
-import { CommentingWidget } from "./comments/commenting";
-import { CommentingStates } from "./comments/states";
-import { CommentingDataProvider } from "./comments/provider";
-import { CommentingDataReceiver } from "./comments/receiver";
-import { CommentingIndicatorHandler } from "./comments/indicator";
+import { CommentingWidget } from './comments/commenting';
+import { CommentingStates } from './comments/states';
+import { CommentingDataProvider } from './comments/provider';
+import { CommentingDataReceiver } from './comments/receiver';
+import { CommentingIndicatorHandler } from './comments/indicator';
 
 /**
  * CommentingUI
@@ -60,16 +60,16 @@ export function activate(
   service: ICommentingServiceConnection
 ) {
   // Create receiver object
-  receiver = new CommentingDataReceiver(states, browserFactory, service);
+  receiver = new CommentingDataReceiver(states, service, docManager);
 
   // Create CommentingUI React widget
   commentingUI = new CommentingWidget(provider, receiver);
-  commentingUI.id = "jupyterlab-commenting:commentsUI";
-  commentingUI.title.iconClass = "jp-ChatIcon jp-SideBar-tabIcon";
-  commentingUI.title.caption = "Commenting";
+  commentingUI.id = 'jupyterlab-commenting:commentsUI';
+  commentingUI.title.iconClass = 'jp-ChatIcon jp-SideBar-tabIcon';
+  commentingUI.title.caption = 'Commenting';
 
   // Add widget to the right area
-  labShell.add(commentingUI, "right");
+  labShell.add(commentingUI, 'right');
 
   // Create CommentingIndicatorHandler
   indicatorHandler = new CommentingIndicatorHandler(
@@ -108,7 +108,7 @@ export function activate(
 
 // creates extension
 const commentingExtension: JupyterFrontEndPlugin<void> = {
-  id: "jupyterlab-commenting:commentsUI",
+  id: 'jupyterlab-commenting:commentsUI',
   autoStart: true,
   requires: [
     ILabShell,
@@ -123,7 +123,7 @@ const commentingExtension: JupyterFrontEndPlugin<void> = {
 const commentServiceExtension: JupyterFrontEndPlugin<
   ICommentingServiceConnection
 > = {
-  id: "jupyterlab-commenting-service-server",
+  id: 'jupyterlab-commenting-service-server',
   autoStart: true,
   requires: [],
   provides: ICommentingServiceConnection,


### PR DESCRIPTION
Comments for this extension are now going to be stored in a SQL database.

There is two Jupyterlab server proxies running. One for [Datasette](https://github.com/simonw/datasette) and the other for [FastAPI](https://github.com/tiangolo/fastapi).

[Datasette](https://github.com/simonw/datasette)  is used to serve the database in a clean and easily navigable way.

[FastAPI](https://github.com/tiangolo/fastapi) does many things. First off, it is used for all the database commands and requests like getting comments and saving comments using [sqlite_utils](https://github.com/simonw/sqlite-utils). FastAPI also provides two styles of docs for the API. A [Swagger UI](https://github.com/swagger-api/swagger-ui) and [ReDoc](https://github.com/Rebilly/ReDoc) viewer that are easily accessible by appending `/docs` or `/redoc` at the end of the proxy URL. 