### PR TITLE
Do not call chdir to run server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ comments.db
 *.tgz
 yarn.lock
 package-lock.json
+dist/

--- a/backend/jupyterlab_commenting_service_server/service.py
+++ b/backend/jupyterlab_commenting_service_server/service.py
@@ -18,7 +18,8 @@ def start():
     database = os.path.join(path, 'comments.db')
 
     try:
-        open(database, "w+")
+        with open(database, "w+") as f:
+            pass
     except FileNotFoundError as f:
         print('The file %s could not be found or opened' % (f.filename))
 
@@ -38,7 +39,6 @@ def start():
 
 def fastapi():
     path = os.path.dirname(os.path.abspath(__file__))
-    os.chdir(path)
 
     return {
         'command': [
@@ -49,7 +49,9 @@ def fastapi():
             '--port',
             '{port}',
             '--proxy-headers',
-            '--reload'
+            '--reload',
+            '--app-dir',
+            path
         ],
         'timeout': 60,
         'port': 0,  # 30000

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -27,7 +27,7 @@ extra_files = get_path_files(path)
 
 setuptools.setup(
     name="jupyterlab-commenting-service-server",
-    version='0.1',
+    version='0.3.1',
     license='BSD-3-Clause',
     author='CalPoly/Quansight',
     author_email='jupyterlab@localhost',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/commenting-extension",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A JupyterLab extension to support commenting and annotation.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [X] Read and understand the [Code of Conduct][code-of-conduct].
-   [X] Read and understood the [licensing terms][license].
-   [X] Searched for existing issues and pull requests **before** submitting this pull request.
-   [ ] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [X] Submitted against `master` branch.

## Description

> What is the purpose of this pull request?

This pull request:

-  Replaces executing `chdir` with just passing an extension folder as an argument for `uvicorn` script.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   I've faced a new issue: every new terminal window in the running notebook is opening in the `jupyterlab_commenting` extension folder. Now it's fixed.

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.